### PR TITLE
fix: expand audit workflow coverage and remove legacy repo alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 - reporium-api: /health, /repos, /search endpoints responding
 - reporium-db: index.json freshness and repo count
-- All GitHub Actions workflows: pass/fail status across 8 repos
+- All GitHub Actions workflows: pass/fail status across the active Reporium suite repos
 
 ## Usage
 
@@ -23,7 +23,8 @@ export GH_TOKEN=...
 python -m reporium_audit run
 ```
 
-Produces `AUDIT_REPORT.md` with full results table.
+Produces a local `AUDIT_REPORT.md` with the full results table.
+The report is generated at runtime and is not tracked in git.
 
 ## Nightly Schedule
 

--- a/reporium_audit/checks/workflows.py
+++ b/reporium_audit/checks/workflows.py
@@ -4,24 +4,28 @@ from __future__ import annotations
 
 import httpx
 
-REPOS = [
-    "perditioinc/forksync",
+ACTIVE_SUITE_REPOS = [
+    "perditioinc/reporium",
+    "perditioinc/reporium-api",
+    "perditioinc/reporium-audit",
     "perditioinc/reporium-db",
     "perditioinc/reporium-dataset",
-    "perditioinc/portfolio",
-    "perditioinc/reporium-roadmap",
+    "perditioinc/reporium-events",
+    "perditioinc/reporium-ingestion",
     "perditioinc/reporium-metrics",
-    "perditioinc/repo-intelligence",
-    "perditioinc/reporium-api",
+    "perditioinc/reporium-roadmap",
+    "perditioinc/reporium-scoring",
+    "perditioinc/reporium-security",
+    "perditioinc/reporium-system-design",
 ]
 
 
 async def check_workflows(token: str) -> list[dict]:
-    """Check latest workflow run status for all tracked repos."""
+    """Check latest workflow run status for the active Reporium suite repos."""
     results = []
     async with httpx.AsyncClient(timeout=15) as client:
         headers = {"Authorization": f"Bearer {token}", "Accept": "application/vnd.github.v3+json"}
-        for repo in REPOS:
+        for repo in ACTIVE_SUITE_REPOS:
             try:
                 r = await client.get(
                     f"https://api.github.com/repos/{repo}/actions/runs?per_page=1",

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,22 @@
+from reporium_audit.checks.workflows import ACTIVE_SUITE_REPOS
+
+
+def test_active_suite_repos_match_current_suite() -> None:
+    assert ACTIVE_SUITE_REPOS == [
+        "perditioinc/reporium",
+        "perditioinc/reporium-api",
+        "perditioinc/reporium-audit",
+        "perditioinc/reporium-db",
+        "perditioinc/reporium-dataset",
+        "perditioinc/reporium-events",
+        "perditioinc/reporium-ingestion",
+        "perditioinc/reporium-metrics",
+        "perditioinc/reporium-roadmap",
+        "perditioinc/reporium-scoring",
+        "perditioinc/reporium-security",
+        "perditioinc/reporium-system-design",
+    ]
+
+
+def test_legacy_repo_intelligence_alias_is_removed() -> None:
+    assert "perditioinc/repo-intelligence" not in ACTIVE_SUITE_REPOS


### PR DESCRIPTION
## Summary
- expand workflow audit coverage to the active Reporium suite repos
- replace the legacy repo-intelligence alias with reporium-scoring
- make the AUDIT_REPORT.md policy explicit in the README and keep it untracked runtime output
- add regression tests for the tracked repo list

## Validation
- pytest -q
- verified the active workflow repo list in code output
- confirmed AUDIT_REPORT.md is generated locally and not tracked in git

## Follow-up
- after review/merge to dev, open promotion PR from dev to main