### PR TITLE
fix: expand /library/full contract audit — fix private-repo check, add schema drift tests

### DIFF
--- a/reporium_audit/checks/contract.py
+++ b/reporium_audit/checks/contract.py
@@ -1,4 +1,4 @@
-"""Check that /library/full satisfies CONTRACT.md — no null required fields."""
+"""Check that /library/full satisfies the public payload contract."""
 
 from __future__ import annotations
 
@@ -14,6 +14,133 @@ ENRICHED_FIELDS = [
     "builders", "pmSkills", "industries", "aiDevSkills", "programmingLanguages",
     "commitStats", "languageBreakdown", "languagePercentages",
 ]
+
+LIST_FIELDS = [
+    "allCategories",
+    "enrichedTags",
+    "builders",
+    "pmSkills",
+    "industries",
+    "aiDevSkills",
+    "programmingLanguages",
+]
+
+DICT_FIELDS = [
+    "commitStats",
+    "languageBreakdown",
+    "languagePercentages",
+]
+
+
+def _repo_label(repo: dict) -> str:
+    """Return the most useful repo identifier available for audit messages."""
+    return repo.get("fullName") or repo.get("name") or "?"
+
+
+def _validate_repos(repos: list[dict]) -> list[dict]:
+    """Validate repo payloads for nulls, identity drift, and type drift."""
+    results: list[dict] = []
+
+    private = [repo.get("fullName") or repo.get("name", "?") for repo in repos if repo.get("isPrivate")]
+    results.append({
+        "check": "contract: no private repos exposed",
+        "status": "PASS" if not private else "FAIL",
+        "detail": f"{len(repos)} public repos" if not private else f"{len(private)} private repos: {private[:5]}",
+    })
+
+    null_issues = []
+    for repo in repos:
+        for field in REQUIRED_FIELDS:
+            val = repo.get(field)
+            if val is None or val == "":
+                null_issues.append(f"{_repo_label(repo)}.{field}")
+
+    results.append({
+        "check": "contract: no null required fields",
+        "status": "PASS" if not null_issues else "FAIL",
+        "detail": "0 nulls" if not null_issues else f"{len(null_issues)} nulls: {null_issues[:5]}",
+    })
+
+    enriched_nulls = []
+    for repo in repos:
+        for field in ENRICHED_FIELDS:
+            if repo.get(field) is None:
+                enriched_nulls.append(f"{_repo_label(repo)}.{field}")
+
+    results.append({
+        "check": "contract: no null enriched fields",
+        "status": "PASS" if not enriched_nulls else "WARN",
+        "detail": "0 nulls" if not enriched_nulls else f"{len(enriched_nulls)} nulls: {enriched_nulls[:5]}",
+    })
+
+    malformed_full_names = []
+    duplicate_full_names = set()
+    seen_full_names = set()
+    name_collisions: dict[str, set[str]] = {}
+    url_mismatches = []
+    type_issues = []
+
+    for repo in repos:
+        label = _repo_label(repo)
+        full_name = repo.get("fullName")
+        name = repo.get("name")
+        url = repo.get("url", "")
+
+        if not isinstance(full_name, str) or full_name.count("/") != 1:
+            malformed_full_names.append(label)
+        else:
+            if full_name in seen_full_names:
+                duplicate_full_names.add(full_name)
+            seen_full_names.add(full_name)
+
+        if isinstance(name, str) and isinstance(full_name, str):
+            name_collisions.setdefault(name, set()).add(full_name)
+
+        if isinstance(url, str) and isinstance(full_name, str) and full_name and not url.rstrip("/").endswith(full_name):
+            url_mismatches.append(label)
+
+        for field in LIST_FIELDS:
+            value = repo.get(field)
+            if value is not None and not isinstance(value, list):
+                type_issues.append(f"{label}.{field}={type(value).__name__}")
+
+        for field in DICT_FIELDS:
+            value = repo.get(field)
+            if value is not None and not isinstance(value, dict):
+                type_issues.append(f"{label}.{field}={type(value).__name__}")
+
+    results.append({
+        "check": "contract: fullName uses owner/name",
+        "status": "PASS" if not malformed_full_names else "FAIL",
+        "detail": "All repos have owner/name fullName" if not malformed_full_names else f"{len(malformed_full_names)} malformed: {malformed_full_names[:5]}",
+    })
+
+    collisions = sorted(name for name, full_names in name_collisions.items() if len(full_names) > 1)
+    results.append({
+        "check": "contract: repo names are globally unique",
+        "status": "WARN" if collisions else "PASS",
+        "detail": "No name collisions" if not collisions else f"{len(collisions)} collisions: {collisions[:5]}",
+    })
+
+    results.append({
+        "check": "contract: fullName values are unique",
+        "status": "PASS" if not duplicate_full_names else "FAIL",
+        "detail": "No duplicate fullName values" if not duplicate_full_names else f"{len(duplicate_full_names)} duplicates: {sorted(duplicate_full_names)[:5]}",
+    })
+
+    results.append({
+        "check": "contract: repo URLs match fullName",
+        "status": "PASS" if not url_mismatches else "FAIL",
+        "detail": "All repo URLs align with fullName" if not url_mismatches else f"{len(url_mismatches)} mismatches: {url_mismatches[:5]}",
+    })
+
+    results.append({
+        "check": "contract: enriched field types are stable",
+        "status": "PASS" if not type_issues else "FAIL",
+        "detail": "No type drift detected" if not type_issues else f"{len(type_issues)} type issues: {type_issues[:5]}",
+    })
+
+    return results
 
 
 async def check_contract(api_url: str) -> list[dict]:
@@ -32,42 +159,7 @@ async def check_contract(api_url: str) -> list[dict]:
 
             data = r.json()
             repos = data.get("repos", [])
-
-            # Check: no private repos
-            private = [repo["name"] for repo in repos if repo.get("isFork") or repo.get("isPrivate")]
-            results.append({
-                "check": "contract: no private/fork repos exposed",
-                "status": "PASS" if len(private) == 0 else "FAIL",
-                "detail": f"{len(repos)} repos, {len(private)} private/fork" if private else f"{len(repos)} public owned repos",
-            })
-
-            # Check: no null required fields
-            null_issues = []
-            for repo in repos:
-                for field in REQUIRED_FIELDS:
-                    val = repo.get(field)
-                    if val is None or val == "":
-                        null_issues.append(f"{repo.get('name', '?')}.{field}")
-
-            results.append({
-                "check": "contract: no null required fields",
-                "status": "PASS" if len(null_issues) == 0 else "FAIL",
-                "detail": f"0 nulls" if not null_issues else f"{len(null_issues)} nulls: {null_issues[:5]}",
-            })
-
-            # Check: no null enriched fields (arrays should be [] not null)
-            enriched_nulls = []
-            for repo in repos:
-                for field in ENRICHED_FIELDS:
-                    val = repo.get(field)
-                    if val is None:
-                        enriched_nulls.append(f"{repo.get('name', '?')}.{field}")
-
-            results.append({
-                "check": "contract: no null enriched fields",
-                "status": "PASS" if len(enriched_nulls) == 0 else "WARN",
-                "detail": f"0 nulls" if not enriched_nulls else f"{len(enriched_nulls)} nulls: {enriched_nulls[:5]}",
-            })
+            results.extend(_validate_repos(repos))
 
         except Exception as e:
             results.append({

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,86 @@
+"""Tests for contract audit checks."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from reporium_audit.checks.contract import _validate_repos, check_contract
+
+
+def _base_repo(**overrides):
+    repo = {
+        "name": "reporium-api",
+        "fullName": "perditioinc/reporium-api",
+        "description": "API service",
+        "url": "https://github.com/perditioinc/reporium-api",
+        "stars": 42,
+        "forks": 3,
+        "isPrivate": False,
+        "readmeSummary": "",
+        "primaryCategory": "",
+        "allCategories": [],
+        "enrichedTags": [],
+        "builders": [],
+        "pmSkills": [],
+        "industries": [],
+        "aiDevSkills": [],
+        "programmingLanguages": [],
+        "commitStats": {},
+        "languageBreakdown": {},
+        "languagePercentages": {},
+    }
+    repo.update(overrides)
+    return repo
+
+
+def test_validate_repos_allows_forks_but_blocks_private_repos():
+    results = _validate_repos([
+        _base_repo(name="openclaw", fullName="perditioinc/openclaw", isFork=True),
+    ])
+
+    private_check = next(r for r in results if r["check"] == "contract: no private repos exposed")
+    assert private_check["status"] == "PASS"
+
+
+def test_validate_repos_flags_identity_and_type_drift():
+    results = _validate_repos([
+        _base_repo(url="https://github.com/perditioinc/wrong", allCategories="agents"),
+        _base_repo(name="reporium-api", fullName="anotherorg/reporium-api"),
+        _base_repo(name="broken", fullName="broken", isPrivate=True),
+    ])
+
+    by_check = {result["check"]: result for result in results}
+    assert by_check["contract: no private repos exposed"]["status"] == "FAIL"
+    assert by_check["contract: fullName uses owner/name"]["status"] == "FAIL"
+    assert by_check["contract: repo names are globally unique"]["status"] == "WARN"
+    assert by_check["contract: repo URLs match fullName"]["status"] == "FAIL"
+    assert by_check["contract: enriched field types are stable"]["status"] == "FAIL"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_check_contract_reports_http_failures():
+    respx.get("https://api.example.com/library/full").mock(
+        return_value=httpx.Response(503, json={"detail": "down"})
+    )
+
+    results = await check_contract("https://api.example.com")
+    assert results == [{
+        "check": "contract: /library/full reachable",
+        "status": "FAIL",
+        "detail": "HTTP 503",
+    }]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_check_contract_validates_repo_payload():
+    respx.get("https://api.example.com/library/full").mock(
+        return_value=httpx.Response(200, json={"repos": [_base_repo(), _base_repo(name="dup", fullName="perditioinc/reporium-api")]})
+    )
+
+    results = await check_contract("https://api.example.com")
+    duplicate_check = next(r for r in results if r["check"] == "contract: fullName values are unique")
+    assert duplicate_check["status"] == "FAIL"


### PR DESCRIPTION
## Summary
- **Fixes false positive**: old check flagged all forks as private exposure — now only checks `isPrivate`
- **fullName format validation**: must be `owner/repo`
- **Duplicate detection**: flags repos with same fullName
- **URL alignment check**: url must end with fullName
- **Type stability checks**: list and dict field types validated
- **test_contract.py**: regression tests for all new checks

Replaces #3 (conflict-free cherry-pick onto current dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)