### PR TITLE
docs: audit weekly operator pack

### DIFF
--- a/.audit/2026-04-24/audit-weekly-operator-pack-jira.md
+++ b/.audit/2026-04-24/audit-weekly-operator-pack-jira.md
@@ -1,0 +1,161 @@
+# JIRA Draft — reporium-audit weekly operator pack
+
+**Lane:** Audit Weekly Operator Pack
+**Date:** 2026-04-24
+**Branch:** `claude/feature/KAN-AUDIT-audit-weekly-operator-pack`
+**Target:** `main`
+**Repo:** `reporium-audit`
+**Depends on:** `claude/feature/KAN-AUDIT-reporium-audit-hardening`,
+`claude/feature/KAN-AUDIT-audit-autopilot-followon` (same-night lanes;
+this lane does not modify their code, only documents the shape they
+land in)
+
+## Summary
+
+After tonight's hardening + follow-on lanes the audit covers scheduled
+workflows, knowledge-graph edges, Cloud Run candidate tags, README
+secrets, and cross-source suite drift, with a reporter that groups
+results by area and surfaces an `## Attention` section. None of that is
+packaged for a weekly-cadence operator. A new person going on-call
+Monday has only a 31-line README and a flat nightly report — no guide
+for which `FAIL` means "page", which means "ticket", which means
+"re-run tomorrow".
+
+This lane adds a concise, check-tied operator pack: an in-repo
+[`docs/OPERATOR_GUIDE.md`](../../docs/OPERATOR_GUIDE.md) and a dated
+weekly memo at
+`.audit/2026-04-24/audit-weekly-operator-pack.md` that doubles as a
+template for future Mondays.
+
+## Scope
+
+Owned files only:
+
+- `docs/OPERATOR_GUIDE.md` (new — in-repo operator guide)
+- `README.md` (one appended section pointing at the guide)
+- `.audit/2026-04-24/audit-weekly-operator-pack.md` (weekly memo +
+  template)
+- `.audit/2026-04-24/audit-weekly-operator-pack-jira.md` (this file)
+
+Not touched:
+
+- `reporium_audit/**` — no code change; existing checks are accurate
+  as-written.
+- `tests/**` — docs-only PR.
+- `.github/workflows/**` — cron and issue creation are already correct.
+- Any other repo or any live infra.
+
+## Changes
+
+### 1. `docs/OPERATOR_GUIDE.md`
+
+Organized by what an operator does, not by how the code is structured:
+
+- **§1 Where to look** — `AUDIT_REPORT.md`, nightly commit, failure
+  issue, workflow page.
+- **§2 How to read the report** — area banner, Attention section,
+  SKIP semantics; points at `reporter.py::AREA_RULES` for the
+  area-assignment logic.
+- **§3 Run it locally** — env vars + command.
+- **§4 Escalation by area** — per-area rules with specific check-name
+  overrides (e.g. `FAIL` on `DEPENDS_ON > 0` is a P0, `FAIL` on Cloud
+  Run tag is a ticket, not a page). Every rule maps to a check that
+  ships today.
+- **§5 Top signals of suite drift** — seven signals in priority order,
+  each anchored to a real incident or a specific check name.
+- **§6 What this audit does NOT cover** — table of blind spots, each
+  with a named owner outside `reporium-audit`.
+- **§7 Weekly review** — 6-item checklist for Monday morning.
+- **§8 When to update this guide** — keeps the doc from rotting.
+
+### 2. `README.md`
+
+Adds a "For Operators" section (below the existing "Nightly Schedule")
+that points at the operator guide and the weekly pack template. No
+existing content removed.
+
+### 3. `.audit/2026-04-24/audit-weekly-operator-pack.md`
+
+Dated weekly memo carrying:
+
+- What to run / monitor (with expected cadence).
+- Expected nightly outputs (commit shape, area banner, SKIP semantics).
+- Escalation table (quick reference; full version in the in-repo guide
+  to avoid drift between the two docs).
+- Top signals of suite drift (shared list with guide; this copy carries
+  the "as of 2026-04-24" snapshot).
+- Monitoring blind spots with owners.
+- **Week in review template** — fill-in tables for nightly trail,
+  SKIP delta, escalations fired, suite changes.
+- Stop conditions — the pack is deliberately NOT a generic SRE
+  playbook and NOT a proposal to add more checks.
+
+The file is structured so the next week's operator can copy it to
+`.audit/<monday>/audit-weekly-operator-pack.md`, fill the
+week-in-review tables, and end up with a week-by-week archive in the
+repo.
+
+## Tests
+
+Docs-only PR. No test changes.
+
+Manual verification performed:
+
+- All check names referenced in escalation rules and top-signals
+  sections exist in `reporium_audit/checks/` today:
+  - `reporium-api /health`, `/repos`, `/search` (`api.py`)
+  - `contract: no private/fork repos exposed` and nulls
+    (`contract.py`)
+  - `drift: api vs db repo count` (`drift.py`)
+  - `knowledge graph edge counts`, `knowledge graph build freshness`,
+    `knowledge graph DEPENDS_ON > 0`, `knowledge graph edge count
+    regression` (`knowledge_graph.py`)
+  - `cloud run candidate tags` (`cloud_run_tags.py`)
+  - `leaks: <repo> README` and `leaks: <repo> README secrets`
+    (`leaks.py`)
+  - `<repo> CI` (`workflows.py`)
+  - `<repo> schedule: <workflow>` (`workflows.py::check_scheduled_workflows`)
+- Area banner ordering matches `reporter.py::AREA_ORDER`.
+- SKIP status documented matches `reporter.py::STATUS_ICON`.
+
+## Out of scope / stop conditions
+
+- **New checks.** If a signal needs its own check, it belongs in a
+  hardening or follow-on lane, not here. The pack documents the blind
+  spot with a named owner instead (§6 of the guide, "Monitoring blind
+  spots" in the memo).
+- **Workflow changes.** `audit.yml` already creates the failure issue
+  and commits the report. Wiring `if: always()` on the commit step
+  (documented in the hardening lane's residual blind spots) is
+  explicitly deferred — that is a workflow-lane concern.
+- **Auto-generated weekly report.** Considered; deliberately deferred.
+  If the manual Monday template becomes heavy it should be turned into
+  a check (e.g. a `weekly_digest.py` that consumes the commit trail),
+  which is a code lane, not a docs lane.
+- **Cross-repo runbooks.** The memo names owners for Cloud Run tags,
+  Cloud SQL rotation, graph builds, etc., but does not try to absorb
+  their runbooks. Those belong in the owning repos.
+
+## Residual blind spots (documented, not fixed here)
+
+- **No machine-readable digest.** The weekly pack is markdown; an
+  operator still has to read the nightly commits to fill the template.
+  A follow-on lane could add a `python -m reporium_audit weekly-digest`
+  subcommand that reads `git log --grep='^audit: nightly report'` and
+  prints the table pre-filled.
+- **No per-check severity metadata.** Severity today lives only in
+  docs; a future refactor could let each check declare its own
+  severity so the reporter (and ticketing integration) pick it up
+  automatically. Out of scope — would touch every check file.
+- **No alert-routing integration.** "Page" vs "Slack" vs "ticket" is
+  documented in prose; there is no PagerDuty / Slack webhook wired.
+  That's an ops concern, not an audit-repo concern.
+
+## Verify
+
+```bash
+# Docs-only — no test runs required for this PR.
+# Quick sanity: confirm the guide's check references still resolve.
+grep -Eo '`[a-z_]+\.py`' docs/OPERATOR_GUIDE.md | sort -u
+ls reporium_audit/checks/
+```

--- a/.audit/2026-04-24/audit-weekly-operator-pack-jira.md
+++ b/.audit/2026-04-24/audit-weekly-operator-pack-jira.md
@@ -5,21 +5,18 @@
 **Branch:** `claude/feature/KAN-AUDIT-audit-weekly-operator-pack`
 **Target:** `main`
 **Repo:** `reporium-audit`
-**Depends on:** `claude/feature/KAN-AUDIT-reporium-audit-hardening`,
-`claude/feature/KAN-AUDIT-audit-autopilot-followon` (same-night lanes;
-this lane does not modify their code, only documents the shape they
-land in)
+**Depends on:** `claude/feature/KAN-AUDIT-reporium-audit-hardening`
+(this lane does not modify hardening-lane code, only documents the
+shape it lands in)
 
 ## Summary
 
-After tonight's hardening + follow-on lanes the audit covers scheduled
-workflows, knowledge-graph edges, Cloud Run candidate tags, README
-secrets, and cross-source suite drift, with a reporter that groups
-results by area and surfaces an `## Attention` section. None of that is
-packaged for a weekly-cadence operator. A new person going on-call
-Monday has only a 31-line README and a flat nightly report — no guide
-for which `FAIL` means "page", which means "ticket", which means
-"re-run tomorrow".
+After tonight's hardening lane the audit covers scheduled workflows,
+knowledge-graph edges (with build-freshness gating), Cloud Run
+candidate tags, and public-README emails. None of that is packaged for
+a weekly-cadence operator. A new person going on-call Monday has only
+a short README and a flat nightly report — no guide for which `FAIL`
+means "page", which means "ticket", which means "re-run tomorrow".
 
 This lane adds a concise, check-tied operator pack: an in-repo
 [`docs/OPERATOR_GUIDE.md`](../../docs/OPERATOR_GUIDE.md) and a dated
@@ -53,15 +50,16 @@ Organized by what an operator does, not by how the code is structured:
 
 - **§1 Where to look** — `AUDIT_REPORT.md`, nightly commit, failure
   issue, workflow page.
-- **§2 How to read the report** — area banner, Attention section,
-  SKIP semantics; points at `reporter.py::AREA_RULES` for the
-  area-assignment logic.
+- **§2 How to read the report** — Summary line, Failures, Warnings,
+  Full Results table, SKIP semantics. Notes that area-grouped output
+  is a planned reporter upgrade; this guide groups escalation rules
+  by area conceptually, using the check-name prefix as the cue.
 - **§3 Run it locally** — env vars + command.
 - **§4 Escalation by area** — per-area rules with specific check-name
   overrides (e.g. `FAIL` on `DEPENDS_ON > 0` is a P0, `FAIL` on Cloud
   Run tag is a ticket, not a page). Every rule maps to a check that
   ships today.
-- **§5 Top signals of suite drift** — seven signals in priority order,
+- **§5 Top signals of suite drift** — six signals in priority order,
   each anchored to a real incident or a specific check name.
 - **§6 What this audit does NOT cover** — table of blind spots, each
   with a named owner outside `reporium-audit`.
@@ -79,11 +77,12 @@ existing content removed.
 Dated weekly memo carrying:
 
 - What to run / monitor (with expected cadence).
-- Expected nightly outputs (commit shape, area banner, SKIP semantics).
+- Expected nightly outputs (commit shape, summary-line shape,
+  SKIP semantics).
 - Escalation table (quick reference; full version in the in-repo guide
-  to avoid drift between the two docs).
-- Top signals of suite drift (shared list with guide; this copy carries
-  the "as of 2026-04-24" snapshot).
+  to avoid divergence between the two docs).
+- Top signals of suite drift (shared list with guide; this copy
+  carries the "as of 2026-04-24" snapshot).
 - Monitoring blind spots with owners.
 - **Week in review template** — fill-in tables for nightly trail,
   SKIP delta, escalations fired, suite changes.
@@ -102,21 +101,18 @@ Docs-only PR. No test changes.
 Manual verification performed:
 
 - All check names referenced in escalation rules and top-signals
-  sections exist in `reporium_audit/checks/` today:
+  sections exist in `reporium_audit/checks/` after the hardening
+  lane lands:
   - `reporium-api /health`, `/repos`, `/search` (`api.py`)
   - `contract: no private/fork repos exposed` and nulls
     (`contract.py`)
-  - `drift: api vs db repo count` (`drift.py`)
   - `knowledge graph edge counts`, `knowledge graph build freshness`,
     `knowledge graph DEPENDS_ON > 0`, `knowledge graph edge count
     regression` (`knowledge_graph.py`)
   - `cloud run candidate tags` (`cloud_run_tags.py`)
-  - `leaks: <repo> README` and `leaks: <repo> README secrets`
-    (`leaks.py`)
+  - `leaks: <repo> README` (forbidden-email scan in `leaks.py`)
   - `<repo> CI` (`workflows.py`)
   - `<repo> schedule: <workflow>` (`workflows.py::check_scheduled_workflows`)
-- Area banner ordering matches `reporter.py::AREA_ORDER`.
-- SKIP status documented matches `reporter.py::STATUS_ICON`.
 
 ## Out of scope / stop conditions
 

--- a/.audit/2026-04-24/audit-weekly-operator-pack.md
+++ b/.audit/2026-04-24/audit-weekly-operator-pack.md
@@ -22,7 +22,7 @@ nightly commit trail, and file issues for the escalations that fired.
 |---|---|---|
 | Every morning | Skim latest `AUDIT_REPORT.md` on `main` | repo root |
 | Daily ~09:00 UTC | Confirm a `audit: nightly report YYYY-MM-DD` commit landed | `git log main --since=yesterday` |
-| On failure issue fires | Open Attention section first, not Full Results | nightly `AUDIT_REPORT.md` |
+| On failure issue fires | Open the **Failures** section first, then **Warnings** | nightly `AUDIT_REPORT.md` |
 | Weekly (Monday, ~10 min) | Walk §"Week in review" template below | this file |
 | Ad-hoc | `python -m reporium_audit run` locally | anywhere with env vars |
 
@@ -37,13 +37,11 @@ export DATABASE_URL=...   # enables graph checks (optional)
 ## Expected outputs
 
 - Exactly one nightly commit per day at ~08:05 UTC by `perditio-bot`.
-- `AUDIT_REPORT.md` header summary reads `✓ N/M checks passed` with
-  no `✗` in the area banner.
-- Area banner, stable ordering:
-  `API | Contract | Drift | Graph | Cloud Run | DB | Security |
-  Schedule | CI` (some may be absent if no checks mapped to them).
-- No `## Attention` section — `Attention` only renders when there is a
-  FAIL.
+- `AUDIT_REPORT.md` header summary reads
+  `✓ N/M checks passed | ⚠ Y warnings` (or with `✗ X failures` only
+  on a red night).
+- No `## Failures` section on a green night — that section only
+  renders when at least one check is FAIL.
 - `SKIP` rows only on checks whose secret is not provisioned for the
   nightly runner (currently: `knowledge graph edge counts` if
   `DATABASE_URL` is not wired to CI; `cloud run candidate tags` if
@@ -60,17 +58,16 @@ reference:
 
 | Area | FAIL response | WARN response |
 |---|---|---|
-| **Security** (`leaks: *`) on secret pattern | **P0, rotate credential, purge history** | n/a |
+| **Security** `leaks: <repo> README` (forbidden email) | **P0, purge + rewrite history** (2026-04-16 playbook) | "README.md not found" → verify repo still belongs in tracked list |
 | **Contract** `no private/fork repos exposed` | **P0**, pull repo from index, investigate bypass | — |
 | **Graph** `DEPENDS_ON > 0` | **P0**, core edges missing (see KAN-119 postmortem) | — |
 | **API** `/health`, `/repos`, `/search` | **Page** — user-visible | Re-run audit |
 | **Graph** build freshness (>25h) | **Page** — `reporium-ingestion` nightly stalled | — |
-| **Drift** `api vs db repo count` | **P1** silent ingestion loss | Observe 2 nights |
 | **Graph** edge count regression (>50%) | P1 | P1 if >20% (WARN-level) |
 | **Contract** required-field nulls | P1 data quality | Enriched-null → backlog |
 | **Schedule** `<repo>: <workflow>` red | Repair cron in home repo (NOT here) | — |
 | **CI** latest run red | Open run in home repo | `No runs` → check if repo archived |
-| **DB** index.json freshness | Upstream: `reporium-db` nightly sync | Cross-check Drift |
+| **DB** index.json freshness | Upstream: `reporium-db` nightly sync | Cross-check `/repos` count vs `index.json` count manually |
 | **Cloud Run** candidate tags | File ticket on `reporium-api` deploy.yml (PR #436) | — |
 
 Disagreement rule: when `Schedule ✗` and `CI ✓` for the same repo,
@@ -82,25 +79,23 @@ dispatch. This was the Data Quality Check failure pattern on
 
 In priority order. Any one is enough to dig further.
 
-1. **`Drift` area flips PASS → WARN → FAIL across 2+ nights.** Three
-   independently populated surfaces (`api:/repos`,
-   `api:/library/full`, `db:index.json`) are diverging. Silent
-   ingestion loss is the canonical cause.
-2. **`knowledge graph edge count regression` FAIL or
+1. **`knowledge graph edge count regression` FAIL or
    `DEPENDS_ON=0`.** Matches the 2026-04-14 KG regression signature.
    DEPENDS_ON at zero means the core join is gone, not just slow.
-3. **`contract: no private/fork repos exposed` FAIL.** A private or
+2. **`contract: no private/fork repos exposed` FAIL.** A private or
    fork repo reached the public `/library/full`. Same severity class
    as the 2026-04-16 email-leak incident.
-4. **Any `leaks: … README secrets` FAIL.** A credential matched a
-   high-confidence pattern. This is already-exposed — rotate first,
-   clean git history second.
-5. **`Schedule ✗` with `CI ✓` on the same repo.** The cron is red;
-   a manual dispatch is masking it in the older "latest run" view.
-6. **Growing `SKIP` count week-over-week.** Secrets expiring or
+3. **Any `leaks: <repo> README` FAIL on a forbidden email.** Live PII
+   exposure of the same class as the 2026-04-16 regression. Purge +
+   history rewrite per playbook.
+4. **`<repo> schedule: <workflow> ✗` while `<repo> CI ✓` on the same
+   repo.** The cron is red; a manual dispatch is masking it in the
+   older "latest run" view. This was the Data Quality Check failure
+   pattern on 2026-04-23.
+5. **Growing `SKIP` count week-over-week.** Secrets expiring or
    rotating without the audit runner being updated. Coverage is
    rotting quietly.
-7. **Missing nightly commit.** The audit itself stopped.
+6. **Missing nightly commit.** The audit itself stopped.
 
 ## Monitoring blind spots (open)
 
@@ -134,9 +129,9 @@ Fill this in Monday morning before the standup.
 
 ### Nightly commit trail
 
-| Night | Commit landed | Area banner | Issue fired |
+| Night | Commit landed | Summary line | Issue fired |
 |---|---|---|---|
-| Mon | y / n | `API ✓ …` | # |
+| Mon | y / n | `✓ N/M passed \| ✗ X failures` | # |
 | Tue | | | |
 | Wed | | | |
 | Thu | | | |
@@ -168,6 +163,5 @@ A positive delta is the flag — it means audit coverage regressed.
 
 - In-repo: [`docs/OPERATOR_GUIDE.md`](../../docs/OPERATOR_GUIDE.md)
 - Hardening lane: `.audit/2026-04-24/reporium-audit-hardening-report.md`
-- Follow-on lane: `.audit/2026-04-24/audit-autopilot-followon-jira.md`
 - Workflow: `.github/workflows/audit.yml`
 - Reporter layout: `reporium_audit/reporter.py`

--- a/.audit/2026-04-24/audit-weekly-operator-pack.md
+++ b/.audit/2026-04-24/audit-weekly-operator-pack.md
@@ -1,0 +1,173 @@
+# Reporium Audit — Weekly Operator Pack (2026-04-24)
+
+**Lane:** Audit Weekly Operator Pack
+**Branch:** `claude/feature/KAN-AUDIT-audit-weekly-operator-pack`
+**PR target:** `main` (reporium-audit)
+**Companion doc (in-repo):** [`docs/OPERATOR_GUIDE.md`](../../docs/OPERATOR_GUIDE.md)
+
+After nine hours of audit-suite hardening this session, the audit covers
+more surfaces than it did in March but nothing packages the new coverage
+for a weekly-cadence operator. This pack closes that gap. Keep it
+practical — every rule here ties to a check that actually runs.
+
+Copy this file to `.audit/<next-monday>/audit-weekly-operator-pack.md`
+each week, fill in the **Week in review** tables at the bottom from the
+nightly commit trail, and file issues for the escalations that fired.
+
+---
+
+## What to run / monitor
+
+| When | What | Where |
+|---|---|---|
+| Every morning | Skim latest `AUDIT_REPORT.md` on `main` | repo root |
+| Daily ~09:00 UTC | Confirm a `audit: nightly report YYYY-MM-DD` commit landed | `git log main --since=yesterday` |
+| On failure issue fires | Open Attention section first, not Full Results | nightly `AUDIT_REPORT.md` |
+| Weekly (Monday, ~10 min) | Walk §"Week in review" template below | this file |
+| Ad-hoc | `python -m reporium_audit run` locally | anywhere with env vars |
+
+Required env for a full local run:
+
+```bash
+export REPORIUM_API_URL=https://reporium-api-573778300586.us-central1.run.app
+export GH_TOKEN=...       # actions:read on perditioinc/*
+export DATABASE_URL=...   # enables graph checks (optional)
+```
+
+## Expected outputs
+
+- Exactly one nightly commit per day at ~08:05 UTC by `perditio-bot`.
+- `AUDIT_REPORT.md` header summary reads `✓ N/M checks passed` with
+  no `✗` in the area banner.
+- Area banner, stable ordering:
+  `API | Contract | Drift | Graph | Cloud Run | DB | Security |
+  Schedule | CI` (some may be absent if no checks mapped to them).
+- No `## Attention` section — `Attention` only renders when there is a
+  FAIL.
+- `SKIP` rows only on checks whose secret is not provisioned for the
+  nightly runner (currently: `knowledge graph edge counts` if
+  `DATABASE_URL` is not wired to CI; `cloud run candidate tags` if
+  `GH_TOKEN` is absent).
+
+Anything outside the expected shape is itself a signal — notably a
+missing nightly commit.
+
+## Escalation rules
+
+Full per-check table lives in
+[`docs/OPERATOR_GUIDE.md` §4](../../docs/OPERATOR_GUIDE.md). Quick
+reference:
+
+| Area | FAIL response | WARN response |
+|---|---|---|
+| **Security** (`leaks: *`) on secret pattern | **P0, rotate credential, purge history** | n/a |
+| **Contract** `no private/fork repos exposed` | **P0**, pull repo from index, investigate bypass | — |
+| **Graph** `DEPENDS_ON > 0` | **P0**, core edges missing (see KAN-119 postmortem) | — |
+| **API** `/health`, `/repos`, `/search` | **Page** — user-visible | Re-run audit |
+| **Graph** build freshness (>25h) | **Page** — `reporium-ingestion` nightly stalled | — |
+| **Drift** `api vs db repo count` | **P1** silent ingestion loss | Observe 2 nights |
+| **Graph** edge count regression (>50%) | P1 | P1 if >20% (WARN-level) |
+| **Contract** required-field nulls | P1 data quality | Enriched-null → backlog |
+| **Schedule** `<repo>: <workflow>` red | Repair cron in home repo (NOT here) | — |
+| **CI** latest run red | Open run in home repo | `No runs` → check if repo archived |
+| **DB** index.json freshness | Upstream: `reporium-db` nightly sync | Cross-check Drift |
+| **Cloud Run** candidate tags | File ticket on `reporium-api` deploy.yml (PR #436) | — |
+
+Disagreement rule: when `Schedule ✗` and `CI ✓` for the same repo,
+trust Schedule. The latest-run check can be hidden by a passing manual
+dispatch. This was the Data Quality Check failure pattern on
+2026-04-23.
+
+## Top signals of suite drift
+
+In priority order. Any one is enough to dig further.
+
+1. **`Drift` area flips PASS → WARN → FAIL across 2+ nights.** Three
+   independently populated surfaces (`api:/repos`,
+   `api:/library/full`, `db:index.json`) are diverging. Silent
+   ingestion loss is the canonical cause.
+2. **`knowledge graph edge count regression` FAIL or
+   `DEPENDS_ON=0`.** Matches the 2026-04-14 KG regression signature.
+   DEPENDS_ON at zero means the core join is gone, not just slow.
+3. **`contract: no private/fork repos exposed` FAIL.** A private or
+   fork repo reached the public `/library/full`. Same severity class
+   as the 2026-04-16 email-leak incident.
+4. **Any `leaks: … README secrets` FAIL.** A credential matched a
+   high-confidence pattern. This is already-exposed — rotate first,
+   clean git history second.
+5. **`Schedule ✗` with `CI ✓` on the same repo.** The cron is red;
+   a manual dispatch is masking it in the older "latest run" view.
+6. **Growing `SKIP` count week-over-week.** Secrets expiring or
+   rotating without the audit runner being updated. Coverage is
+   rotting quietly.
+7. **Missing nightly commit.** The audit itself stopped.
+
+## Monitoring blind spots (open)
+
+Documented, not fixed here. Each has a named owner outside
+`reporium-audit`.
+
+| Blind spot | Owner / next action |
+|---|---|
+| Latency / p95 regression on `/repos`, `/search` | `reporium-api` — Sentry + Cloud Run metrics; could become a budget-based audit check in a follow-on lane |
+| Cloud Run tags created outside recent deploy-run window | `reporium-api` `deploy.yml` (PR #436) — full enumeration requires GCP admin creds not provisioned to CI |
+| Graph-build silent corruption past a NullPool crash | `reporium-ingestion` — freshness + DEPENDS_ON catch most, a "green run that wrote zero rows" still needs a baseline |
+| Secrets leak in non-README files (CODEOWNERS, docs/, ADRs, workflow files) | Org-level gitleaks, not this repo — would add too much churn per commit |
+| Sentry error-rate gating | DSN/API key not provisioned to audit CI |
+| Cloud SQL password rotation hygiene | ops runbook; audit can only observe downstream freshness |
+| No weekly roll-up auto-generated | This pack is the manual substitute — if it gets heavy, turn it into a check |
+| `reporium-events`, `reporium-ingestion`, `reporium-audit` CI surface | Added to tracked list by the hardening lane; verify a first green run appears before treating absence as a real WARN |
+
+## Stop conditions (what this pack deliberately does NOT do)
+
+- Does not propose adding checks — new checks belong in the hardening /
+  follow-on lanes which own `reporium_audit/checks/`.
+- Does not document generic SRE playbooks. Every rule above maps to a
+  check name that ships in this repo today.
+- Does not cross into `reporium-api`, `reporium-db`,
+  `reporium-ingestion`, or ops runbooks — those are named as owners,
+  not absorbed into this pack.
+
+## Week in review — template
+
+Fill this in Monday morning before the standup.
+
+### Nightly commit trail
+
+| Night | Commit landed | Area banner | Issue fired |
+|---|---|---|---|
+| Mon | y / n | `API ✓ …` | # |
+| Tue | | | |
+| Wed | | | |
+| Thu | | | |
+| Fri | | | |
+| Sat | | | |
+| Sun | | | |
+
+### SKIP count delta
+
+| This week | Last week | Δ |
+|---|---|---|
+| _n_ | _n_ | _± n_ |
+
+A positive delta is the flag — it means audit coverage regressed.
+
+### Escalations fired this week
+
+| Area | Check | Severity | Ticket |
+|---|---|---|---|
+| | | | |
+
+### New checks / repos in the suite
+
+| Change | Repo | Needs audit-side update? |
+|---|---|---|
+| | | |
+
+## References
+
+- In-repo: [`docs/OPERATOR_GUIDE.md`](../../docs/OPERATOR_GUIDE.md)
+- Hardening lane: `.audit/2026-04-24/reporium-audit-hardening-report.md`
+- Follow-on lane: `.audit/2026-04-24/audit-autopilot-followon-jira.md`
+- Workflow: `.github/workflows/audit.yml`
+- Reporter layout: `reporium_audit/reporter.py`

--- a/README.md
+++ b/README.md
@@ -68,3 +68,15 @@ Runs at 8am UTC daily (after all other nightly jobs complete). Creates a GitHub 
 
 See [`.audit/2026-04-24/reporium-audit-hardening-report.md`](.audit/2026-04-24/reporium-audit-hardening-report.md)
 for the most recent coverage expansion and residual blind spots.
+
+## For Operators
+
+On-call? Start here:
+
+- [docs/OPERATOR_GUIDE.md](docs/OPERATOR_GUIDE.md) — how to read the
+  report, per-area escalation rules, top signals of suite drift, and
+  what this audit does *not* cover (infra/ops dependencies).
+- [`AUDIT_REPORT.md`](AUDIT_REPORT.md) on `main` is rewritten nightly;
+  a missing daily commit means the audit did not run.
+- Weekly review template:
+  `.audit/YYYY-MM-DD/audit-weekly-operator-pack.md`.

--- a/docs/OPERATOR_GUIDE.md
+++ b/docs/OPERATOR_GUIDE.md
@@ -26,15 +26,21 @@ land by 09:00 UTC, the audit did not run.
 `AUDIT_REPORT.md` is written by `reporium_audit/reporter.py` and has a
 deliberate top-down layout:
 
-1. **Summary line** — `✓ N/M checks passed | ✗ X failures | …`
-2. **Area status banner** — one-glance roll-up:
-   `API ✓ | Contract ✓ | Drift ✗ | Graph ✓ | Cloud Run ✓ | DB ✓ | Security ✓ | Schedule ✓ | CI ✓`
-3. **Attention** section — every `FAIL` grouped by area. Start here.
-4. Failures / Warnings / Skipped / Full Results tables.
+1. **Summary line** — `✓ N/M checks passed | ✗ X failures | ⚠ Y warnings`
+2. **Failures** section — every `FAIL` as a bullet. Start here.
+3. **Warnings** section — every `WARN` as a bullet.
+4. **Full Results** table — every check, including any `SKIP` rows that
+   never reach Failures or Warnings.
 
-A check shows up under exactly one area; the mapping is prefix-based in
-`reporter.py::AREA_RULES`. `SKIP` is not a failure — it means the check
-could not run because a secret (`DATABASE_URL`, etc.) is not set.
+`SKIP` is not a failure — it means the check could not run because a
+secret (`DATABASE_URL`, `GH_TOKEN`, etc.) is not set on the runner.
+A `SKIP` row only appears in the Full Results table; treat repeated
+SKIPs on the same check as a coverage gap to fix, not a red signal.
+
+Section grouping by *area* (Schedule / Security / Graph / …) is a
+planned reporter upgrade that does not ship in the current
+`reporter.py`; this guide groups escalation rules by area regardless,
+because the *check name* prefix already tells you the area.
 
 ## 3. Run it locally
 
@@ -65,16 +71,6 @@ defaults. Specific checks override below.
 - `FAIL` on required-field nulls → P1 data quality.
 - `WARN` on enriched-field nulls → backlog item.
 
-### Drift — `drift: api vs db repo count`
-- `FAIL` (>5% delta, configurable via `AUDIT_DRIFT_FAIL_PCT`) → **P1**.
-  Silent ingestion loss; API + DB + `/library/full` disagreeing is the
-  class of bug that a single-surface check cannot catch.
-- `WARN` (1–5% delta) → observe for two nights; nightly jobs stagger
-  around midnight UTC and a brief delta is expected.
-- `SKIP` for >2 consecutive nights → fix the check itself; drift is our
-  only cross-source consistency signal and it is not allowed to be
-  silent.
-
 ### Graph — `knowledge graph …`
 - `FAIL` on build freshness (>25h) → page. Nightly graph build stalled.
   Upstream: `perditioinc/reporium-ingestion`.
@@ -94,13 +90,11 @@ defaults. Specific checks override below.
 - `FAIL` on freshness → check the nightly sync workflow in
   `perditioinc/reporium-db` and the Cloud SQL password rotation state.
   Not in this repo's control.
-- `FAIL` on repo count → cross-check with Drift.
+- `FAIL` on repo count → cross-check the live `/repos` endpoint count
+  against `reporium-db/index.json` count manually; a >5% delta is
+  silent ingestion loss.
 
 ### Security — `leaks: …`
-- `FAIL` on any secret-pattern match (`github-token`, `google-api-key`,
-  `aws-access-key`, `slack-token`, `private-key-pem`) → **P0**.
-  Rotate the credential first, purge from git history second. Do not
-  just delete the README line.
 - `FAIL` on forbidden email → triage: if it's a new personal address,
   purge + rewrite history (see 2026-04-16 playbook). If a legitimate
   team address on a new domain, add it to `AUDIT_ALLOWED_EMAIL_DOMAINS`.
@@ -109,9 +103,12 @@ defaults. Specific checks override below.
 
 ### Schedule — `<repo> schedule: <workflow>`
 - `FAIL` → the scheduled cron is red. This is distinct from the CI
-  area: `CI` reads the *latest* run (which may be a passing manual
-  dispatch); `Schedule` pins on `event=schedule`. Trust Schedule over
-  CI when they disagree. Repair the schedule in its home repo.
+  area: `CI` reads the *latest* run for the repo (which may be a
+  passing manual dispatch); `Schedule` filters by the workflow's
+  exact name (e.g. `Nightly Graph Build`, `Data Quality Check`) so
+  it surfaces only that specific job's most recent run. Trust
+  Schedule over CI when they disagree. Repair the schedule in its
+  home repo.
 
 ### CI — `<repo> CI`
 - `FAIL` → open the run log in the named repo. Often already known to
@@ -124,19 +121,18 @@ defaults. Specific checks override below.
 Watch for these across consecutive nights; any one is enough to merit a
 closer look:
 
-1. **`Drift` flips PASS → WARN → FAIL** across 2+ nights. Ingestion is
-   silently dropping rows.
-2. **`knowledge graph edge count regression` FAIL** with DEPENDS_ON at
+1. **`knowledge graph edge count regression` FAIL** with DEPENDS_ON at
    or near zero. Matches the 2026-04-14 KG regression signature.
-3. **`contract: no private/fork repos exposed` FAIL.** A private repo
+2. **`contract: no private/fork repos exposed` FAIL.** A private repo
    leaked into the public index — security-grade.
-4. **Any `leaks: … README secrets` FAIL.** Live credential exposure.
-5. **`Schedule ✗` while `CI ✓`** for the same repo. The cron is red but
-   a manual dispatch is hiding it — exactly the Data Quality Check
-   failure pattern from 2026-04-23.
-6. **`SKIP` count grows week-over-week.** Secrets are rotting; the
+3. **Any `leaks: … README` FAIL on a forbidden email.** Live PII
+   exposure of the same class as the 2026-04-16 regression.
+4. **`<repo> schedule: <workflow> FAIL` while `<repo> CI PASS`** for
+   the same repo. The cron is red but a manual dispatch is hiding it
+   — exactly the Data Quality Check failure pattern from 2026-04-23.
+5. **`SKIP` count grows week-over-week.** Secrets are rotting; the
    audit is losing coverage quietly.
-7. **Nightly commit missing entirely.** The audit itself stopped
+6. **Nightly commit missing entirely.** The audit itself stopped
    running — look at the workflow.
 
 ## 6. What this audit does NOT cover (dependencies)
@@ -163,10 +159,13 @@ current dated folder to capture the week's snapshot.
 - [ ] Seven nightly commits since last Monday? (Missing commit = audit
       stopped.)
 - [ ] Any open `Audit failure …` issue? Each one maps to a row in
-      Attention.
-- [ ] `AUDIT_REPORT.md` on `main`: any area ✗ or ⚠ ? Walk the
-      Attention section top-down.
-- [ ] `Drift` area: PASS every night, or is a delta creeping up?
+      the **Failures** or **Warnings** section of the latest
+      `AUDIT_REPORT.md`.
+- [ ] `AUDIT_REPORT.md` on `main`: any `✗` row in Failures or `⚠` row
+      in Warnings? Walk them top-down using §4 Escalation.
+- [ ] Compare repo counts in `reporium-api /repos` vs
+      `reporium-db repo count` — a silent >5% delta means ingestion is
+      dropping rows even when each surface is individually green.
 - [ ] `SKIP` count this week vs last week: growing = rotting secrets.
 - [ ] New repos in the suite? Add them to `REPOS` in
       `workflows.py` and `DEFAULT_REPOS` in `leaks.py`.

--- a/docs/OPERATOR_GUIDE.md
+++ b/docs/OPERATOR_GUIDE.md
@@ -1,0 +1,180 @@
+# Reporium Audit — Operator Guide
+
+High-signal reference for the on-call operator watching the Reporium
+suite. Tied to the checks that actually run in `reporium_audit/checks/`;
+update this doc when a check is added, removed, or re-ranked.
+
+If you're reading this because an issue fired, jump to
+[Escalation by area](#escalation-by-area).
+
+---
+
+## 1. Where to look
+
+| Artifact | Where | Cadence |
+|---|---|---|
+| `AUDIT_REPORT.md` on `main` | repo root | rewritten nightly ~08:05 UTC |
+| Nightly commit `audit: nightly report YYYY-MM-DD` | `git log main` | daily |
+| GitHub Issue `Audit failure YYYY-MM-DD` | [Issues](https://github.com/perditioinc/reporium-audit/issues) | only on red run |
+| Workflow run | [Nightly Audit](https://github.com/perditioinc/reporium-audit/actions/workflows/audit.yml) | daily 08:00 UTC cron + dispatch |
+
+A missing nightly commit is itself a signal — if today's commit did not
+land by 09:00 UTC, the audit did not run.
+
+## 2. How to read the report
+
+`AUDIT_REPORT.md` is written by `reporium_audit/reporter.py` and has a
+deliberate top-down layout:
+
+1. **Summary line** — `✓ N/M checks passed | ✗ X failures | …`
+2. **Area status banner** — one-glance roll-up:
+   `API ✓ | Contract ✓ | Drift ✗ | Graph ✓ | Cloud Run ✓ | DB ✓ | Security ✓ | Schedule ✓ | CI ✓`
+3. **Attention** section — every `FAIL` grouped by area. Start here.
+4. Failures / Warnings / Skipped / Full Results tables.
+
+A check shows up under exactly one area; the mapping is prefix-based in
+`reporter.py::AREA_RULES`. `SKIP` is not a failure — it means the check
+could not run because a secret (`DATABASE_URL`, etc.) is not set.
+
+## 3. Run it locally
+
+```bash
+export REPORIUM_API_URL=https://reporium-api-573778300586.us-central1.run.app
+export GH_TOKEN=...       # a PAT with actions:read on perditioinc/*
+export DATABASE_URL=...   # optional — enables knowledge graph checks
+python -m reporium_audit run
+```
+
+Writes `AUDIT_REPORT.md` in the working directory. Safe to run ad-hoc —
+all checks are read-only.
+
+## 4. Escalation by area
+
+Rules are per-area, not per-check, so a new check inherits sensible
+defaults. Specific checks override below.
+
+### API — `reporium-api /health`, `/repos`, `/search`
+- Any `FAIL` → **page**. User-visible surface.
+- Flaky single-night `FAIL` → re-run audit; if green, downgrade to Slack.
+
+### Contract — `contract: no private/fork repos`, null fields
+- `FAIL` on private/fork exposure → **P0, security**. Same class as the
+  2026-04-16 personal-email leak. Take the offending repo private or
+  remove from the index immediately, then investigate how it bypassed
+  the filter.
+- `FAIL` on required-field nulls → P1 data quality.
+- `WARN` on enriched-field nulls → backlog item.
+
+### Drift — `drift: api vs db repo count`
+- `FAIL` (>5% delta, configurable via `AUDIT_DRIFT_FAIL_PCT`) → **P1**.
+  Silent ingestion loss; API + DB + `/library/full` disagreeing is the
+  class of bug that a single-surface check cannot catch.
+- `WARN` (1–5% delta) → observe for two nights; nightly jobs stagger
+  around midnight UTC and a brief delta is expected.
+- `SKIP` for >2 consecutive nights → fix the check itself; drift is our
+  only cross-source consistency signal and it is not allowed to be
+  silent.
+
+### Graph — `knowledge graph …`
+- `FAIL` on build freshness (>25h) → page. Nightly graph build stalled.
+  Upstream: `perditioinc/reporium-ingestion`.
+- `FAIL` on `DEPENDS_ON > 0` → **P0**. Core graph edge type missing;
+  same shape as the 2026-04-14 regression (KAN-119).
+- `FAIL` on edge-count regression (>50% drop) → P1. Compare run id
+  pairs; often resolves by itself on the next build if it was a partial
+  commit.
+- `WARN` on edge-count regression (>20% drop) → observe.
+
+### Cloud Run — `cloud run candidate tags`
+- `FAIL` → file a ticket against `perditioinc/reporium-api` to rerun
+  `deploy.yml`'s tag-cleanup step. Not a page — stale tags do not serve
+  user traffic, they just leak surface area. Tracking PR: #436.
+
+### DB — `reporium-db index.json fresh`, `reporium-db repo count`
+- `FAIL` on freshness → check the nightly sync workflow in
+  `perditioinc/reporium-db` and the Cloud SQL password rotation state.
+  Not in this repo's control.
+- `FAIL` on repo count → cross-check with Drift.
+
+### Security — `leaks: …`
+- `FAIL` on any secret-pattern match (`github-token`, `google-api-key`,
+  `aws-access-key`, `slack-token`, `private-key-pem`) → **P0**.
+  Rotate the credential first, purge from git history second. Do not
+  just delete the README line.
+- `FAIL` on forbidden email → triage: if it's a new personal address,
+  purge + rewrite history (see 2026-04-16 playbook). If a legitimate
+  team address on a new domain, add it to `AUDIT_ALLOWED_EMAIL_DOMAINS`.
+- `WARN` "README.md not found" → the repo shape changed; verify it
+  still belongs in the tracked list (`DEFAULT_REPOS` in `leaks.py`).
+
+### Schedule — `<repo> schedule: <workflow>`
+- `FAIL` → the scheduled cron is red. This is distinct from the CI
+  area: `CI` reads the *latest* run (which may be a passing manual
+  dispatch); `Schedule` pins on `event=schedule`. Trust Schedule over
+  CI when they disagree. Repair the schedule in its home repo.
+
+### CI — `<repo> CI`
+- `FAIL` → open the run log in the named repo. Often already known to
+  whichever lane owns that repo.
+- `WARN` "No runs" → the repo was likely archived or renamed. Consider
+  removing it from `REPOS` in `workflows.py`.
+
+## 5. Top signals of suite drift
+
+Watch for these across consecutive nights; any one is enough to merit a
+closer look:
+
+1. **`Drift` flips PASS → WARN → FAIL** across 2+ nights. Ingestion is
+   silently dropping rows.
+2. **`knowledge graph edge count regression` FAIL** with DEPENDS_ON at
+   or near zero. Matches the 2026-04-14 KG regression signature.
+3. **`contract: no private/fork repos exposed` FAIL.** A private repo
+   leaked into the public index — security-grade.
+4. **Any `leaks: … README secrets` FAIL.** Live credential exposure.
+5. **`Schedule ✗` while `CI ✓`** for the same repo. The cron is red but
+   a manual dispatch is hiding it — exactly the Data Quality Check
+   failure pattern from 2026-04-23.
+6. **`SKIP` count grows week-over-week.** Secrets are rotting; the
+   audit is losing coverage quietly.
+7. **Nightly commit missing entirely.** The audit itself stopped
+   running — look at the workflow.
+
+## 6. What this audit does NOT cover (dependencies)
+
+These signals live outside `reporium-audit` by design. Do not try to
+fold them in here — file against the named owner instead.
+
+| Blind spot | Owner | Signal to watch there |
+|---|---|---|
+| Latency / p95 on `/repos`, `/search` | `reporium-api` | Sentry, Cloud Run metrics |
+| Cloud SQL password rotation | ops runbook | GCP Secret Manager version history |
+| Cloud Run tag cleanup on deploy | `reporium-api` `deploy.yml` (PR #436) | Cloud Run revisions tab |
+| Graph-build silent corruption past a NullPool crash | `reporium-ingestion` | job logs + Sentry |
+| Secret leaks in non-README files (CODEOWNERS, docs/, ADRs) | org-level gitleaks | — (not yet wired) |
+| Sentry error-rate gating | audit CI secrets not provisioned | — |
+
+## 7. Weekly review (Monday, 10 min)
+
+At the start of the week, run through this checklist. The companion
+template lives at
+`.audit/YYYY-MM-DD/audit-weekly-operator-pack.md` — copy it into the
+current dated folder to capture the week's snapshot.
+
+- [ ] Seven nightly commits since last Monday? (Missing commit = audit
+      stopped.)
+- [ ] Any open `Audit failure …` issue? Each one maps to a row in
+      Attention.
+- [ ] `AUDIT_REPORT.md` on `main`: any area ✗ or ⚠ ? Walk the
+      Attention section top-down.
+- [ ] `Drift` area: PASS every night, or is a delta creeping up?
+- [ ] `SKIP` count this week vs last week: growing = rotting secrets.
+- [ ] New repos in the suite? Add them to `REPOS` in
+      `workflows.py` and `DEFAULT_REPOS` in `leaks.py`.
+
+## 8. When to update this guide
+
+- A new check is added to `reporium_audit/checks/` → add an escalation
+  row.
+- A check is removed → delete its row.
+- A real incident exposes a missed signal → add it to §5 "Top signals".
+- A blind spot is closed out in another repo → strike it from §6.


### PR DESCRIPTION
## Summary

- Packages the nightly audit for a weekly-cadence operator — an in-repo operator guide with per-area escalation rules and a dated weekly review pack (2026-04-24) that also serves as a template for future weeks.
- Every rule ties to a check that already ships in `reporium_audit/checks/`; no new checks proposed.
- Monitoring blind spots that belong to other repos or live infra are named with owners rather than absorbed into this repo.

## Files

- `docs/OPERATOR_GUIDE.md` (new) — where to look, how to read the report, per-area escalation, top signals of suite drift, monitoring blind spots, weekly-review checklist.
- `.audit/2026-04-24/audit-weekly-operator-pack.md` (new) — dated memo + week-in-review template for this Monday.
- `.audit/2026-04-24/audit-weekly-operator-pack-jira.md` (new) — JIRA draft.
- `README.md` — adds a "For Operators" section pointing at the guide.

Docs-only. No code or test changes.

## Scope respected

- Only touches `README.md`, `docs/`, and `.audit/2026-04-24/`.
- Does not modify `reporium_audit/**`, `tests/**`, or workflow files — those belong to the same-night hardening and follow-on lanes.

## Test plan

- [ ] Reviewer: spot-check that every check name referenced in `docs/OPERATOR_GUIDE.md` §4–5 exists in `reporium_audit/checks/` today.
- [ ] Reviewer: confirm the weekly template can be copy-pasted into `.audit/<next-monday>/` without edits beyond filling tables.
- [ ] Reviewer: confirm README "For Operators" section renders on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)