### PR TITLE
fix(audit): stop conflating fork with private; lazy-import psycopg2

### DIFF
--- a/reporium_audit/checks/contract.py
+++ b/reporium_audit/checks/contract.py
@@ -33,12 +33,15 @@ async def check_contract(api_url: str) -> list[dict]:
             data = r.json()
             repos = data.get("repos", [])
 
-            # Check: no private repos
-            private = [repo["name"] for repo in repos if repo.get("isFork") or repo.get("isPrivate")]
+            # Check: no private repos.
+            # Forks are intentionally part of the curated catalog (Reporium's
+            # product surface is forks of upstream open-source repos), so they
+            # are not a privacy violation. Only ``isPrivate=true`` is.
+            private = [repo["name"] for repo in repos if repo.get("isPrivate")]
             results.append({
-                "check": "contract: no private/fork repos exposed",
+                "check": "contract: no private repos exposed",
                 "status": "PASS" if len(private) == 0 else "FAIL",
-                "detail": f"{len(repos)} repos, {len(private)} private/fork" if private else f"{len(repos)} public owned repos",
+                "detail": f"{len(repos)} repos, {len(private)} private" if private else f"{len(repos)} public repos",
             })
 
             # Check: no null required fields

--- a/reporium_audit/checks/knowledge_graph.py
+++ b/reporium_audit/checks/knowledge_graph.py
@@ -21,8 +21,6 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-import psycopg2
-
 
 STALE_RUN_THRESHOLD = timedelta(hours=25)
 
@@ -43,6 +41,19 @@ async def check_knowledge_graph(db_url: str) -> list[dict]:
             "check": "knowledge graph edge counts",
             "status": "SKIP",
             "detail": "DATABASE_URL not set -- audit runner has no DB credentials",
+        })
+        return results
+
+    # psycopg2 is imported lazily so the SKIP path above doesn't require the
+    # dep. The audit's declared deps are httpx + python-dotenv only; psycopg2
+    # is only needed when DATABASE_URL is set (issue #13).
+    try:
+        import psycopg2
+    except ImportError as e:
+        results.append({
+            "check": "knowledge graph edge counts",
+            "status": "FAIL",
+            "detail": f"psycopg2 not installed: {e}",
         })
         return results
 

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,106 @@
+"""Tests for /library/full data-contract checks.
+
+Pins the 2026-04-26 fix that stopped conflating ``isFork`` with
+``isPrivate``. Reporium's curated catalog intentionally contains forks
+of upstream open-source repos -- forks are the product, not a privacy
+violation. Only ``isPrivate=true`` rows constitute a contract failure.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from reporium_audit.checks.contract import check_contract
+
+
+API_URL = "https://api.example.test"
+LIBRARY_FULL_URL = f"{API_URL}/library/full"
+
+
+def _repo(name: str, *, is_fork: bool = False, is_private: bool = False) -> dict:
+    return {
+        "name": name,
+        "fullName": f"perditioinc/{name}",
+        "description": "x",
+        "url": f"https://github.com/perditioinc/{name}",
+        "stars": 1,
+        "forks": 0,
+        "isFork": is_fork,
+        "isPrivate": is_private,
+        # enriched fields populated to keep null-checks PASS
+        "readmeSummary": "x",
+        "primaryCategory": "ai",
+        "allCategories": [],
+        "enrichedTags": [],
+        "builders": [],
+        "pmSkills": [],
+        "industries": [],
+        "aiDevSkills": [],
+        "programmingLanguages": [],
+        "commitStats": {},
+        "languageBreakdown": {},
+        "languagePercentages": {},
+    }
+
+
+def _privacy_row(results: list[dict]) -> dict:
+    matches = [r for r in results if "private" in r["check"]]
+    assert len(matches) == 1, f"expected exactly one privacy row, got {results}"
+    return matches[0]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_forks_alone_do_not_trigger_privacy_failure():
+    """Regression: forks are the product surface, not a privacy violation."""
+    repos = [_repo(f"fork-{i}", is_fork=True) for i in range(3)]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+
+    results = await check_contract(API_URL)
+
+    row = _privacy_row(results)
+    assert row["status"] == "PASS"
+    assert "private" in row["check"]
+    assert "fork" not in row["check"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_private_repo_triggers_failure():
+    """Privacy check still catches genuine private exposure."""
+    repos = [
+        _repo("public-fork", is_fork=True),
+        _repo("leaked", is_private=True),
+    ]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+
+    results = await check_contract(API_URL)
+
+    row = _privacy_row(results)
+    assert row["status"] == "FAIL"
+    assert "1 private" in row["detail"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_clean_public_originals_pass():
+    """Mixed clean catalog with no private rows should PASS."""
+    repos = [
+        _repo("original-1"),
+        _repo("fork-1", is_fork=True),
+    ]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+
+    results = await check_contract(API_URL)
+
+    row = _privacy_row(results)
+    assert row["status"] == "PASS"
+    assert "2 public repos" in row["detail"]


### PR DESCRIPTION
## Summary

Two coupled fixes that together convert the audit from "broken" to a trustworthy signal.

- **`contract.py`** — the privacy check was flagging `isFork OR isPrivate` as a single violation. Reporium's curated catalog is intentionally forks of upstream open-source repos — that's the product surface, not a leak. Now flags only `isPrivate=true`.
- **`knowledge_graph.py`** — `psycopg2` is not in the audit's declared deps (`httpx` + `python-dotenv` only), so the module-level import crashed the whole audit. Move the import inside `check_knowledge_graph()` so the SKIP-when-`DATABASE_URL`-missing path runs without the dep. **Closes #13.**

## Why these are coupled

The audit hasn't completed cleanly since ~2026-03-22 because of the `psycopg2` import error (#13). Once #13 is fixed in isolation, the existing contract check would FAIL `200/200` on every nightly run (live probe today: 200 forks / 0 private repos), turning a fixed audit straight back into noisy red. Both fixes need to ship together.

## Policy framing — explicit so future readers can find it

This change encodes the **current product reality**, not a relaxation of privacy posture:

- `/library/full` is intentionally a fork-curation surface. Reporium's product is a curated catalog of public forks of upstream open-source repos.
- The previous check was enforcing an **outdated contract** (forks-as-leak), not catching a live privacy leak. Privacy is intact: live probe on 2026-04-26 returned `0` private rows out of `200`.
- If a future surface (e.g., a `/library/owned` for originals-only) needs a "no forks exposed" check, that belongs as a **separate check on that endpoint** — please don't reintroduce the conflation here under a renamed banner.

## What is NOT changing

- `/library/full` API behavior (this is an audit-only change).
- The "no null required fields" and "no null enriched fields" checks are untouched.
- The privacy posture of the platform — `isPrivate=true` rows still FAIL the check immediately.

## Test plan

- [x] All 31 tests pass locally (`pytest tests/ -v`)
- [x] 3 new tests in `tests/test_contract.py`: forks-alone-pass, private-row-fails, clean-mixed-pass
- [x] Existing `test_knowledge_graph_skips_when_db_url_missing` still passes via the SKIP-before-import short-circuit
- [ ] After merge: `gh workflow run audit.yml --repo perditioinc/reporium-audit` to seed the missed 2026-04-26 nightly row and confirm `contract: no private repos exposed` returns PASS

## Caveat for reviewers

If there is genuine disagreement about whether public forks should be exposed on `/library/full`, **pause this PR and resolve the policy first** — the right fix in that world is on the API, not the audit. Based on live API behavior and product direction, this is requirement drift inside the audit, not a privacy bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)