### PR TITLE
feat(audit): add cache-vs-db consistency invariant for repo detail

### DIFF
--- a/reporium_audit/__main__.py
+++ b/reporium_audit/__main__.py
@@ -10,6 +10,7 @@ import sys
 from dotenv import load_dotenv
 
 from reporium_audit.checks.api import check_api
+from reporium_audit.checks.cache_consistency import check_cache_consistency
 from reporium_audit.checks.cloud_run_tags import check_cloud_run_tags
 from reporium_audit.checks.contract import check_contract
 from reporium_audit.checks.knowledge_graph import check_knowledge_graph
@@ -41,6 +42,7 @@ async def run_audit() -> str:
     (
         api_results,
         contract_results,
+        cache_results,
         db_results,
         wf_results,
         sched_results,
@@ -50,6 +52,7 @@ async def run_audit() -> str:
     ) = await asyncio.gather(
         check_api(api_url),
         check_contract(api_url),
+        check_cache_consistency(api_url),
         check_reporium_db(gh_token),
         check_workflows(gh_token),
         check_scheduled_workflows(gh_token),
@@ -61,6 +64,7 @@ async def run_audit() -> str:
     results: list[dict] = []
     results.extend(api_results)
     results.extend(contract_results)
+    results.extend(cache_results)
     results.extend(db_results)
     results.extend(wf_results)
     results.extend(sched_results)

--- a/reporium_audit/checks/cache_consistency.py
+++ b/reporium_audit/checks/cache_consistency.py
@@ -1,0 +1,241 @@
+"""Cache-vs-DB consistency check for the repo detail surface.
+
+Reporium has two cached endpoints that both report the "primary category"
+of a repo, derived from independent caches with independent TTLs:
+
+- ``/library/full`` — exposes the raw ``repos.primary_category`` column
+  via the ``dbCategory`` field. This is the closest thing the audit
+  runner has to "raw row state" without DB access (Cloud SQL is
+  private-IP per ``reference_cloud_sql_private_ip.md``).
+- ``/repos/<slug>`` — exposes the ``repo_categories`` junction table
+  via the ``categories`` array (each row has ``category_name`` and
+  ``is_primary``). This endpoint has its own ``repos:detail:<slug>``
+  Redis cache with a separate TTL.
+
+The pattern this invariant catches is the recurring "DB row updated ->
+cache not invalidated -> user sees stale" regression (memory entry
+4931, 2026-04-26): an admin backfill writes the ``repos.primary_category``
+column but does not invalidate the per-slug detail cache. For a window
+of TTL hours, ``/library/full`` reflects the new value while
+``/repos/<slug>`` still serves the pre-backfill junction snapshot --
+or vice versa.
+
+The cleanest cross-cache check we can run without DB access is:
+
+    For every sampled repo, the ``dbCategory`` reported by
+    ``/library/full`` must appear as a ``category_name`` in the
+    ``categories`` array returned by ``/repos/<slug>``.
+
+If they diverge, either:
+1. The ``/repos/<slug>`` cache is stale (the staleness regression).
+2. The column was backfilled but the junction never had the matching
+   row (the column-vs-junction drift caught by api#444 / #445).
+
+Both belong to the same family of bugs.
+
+Degradation policy:
+- ``/library/full`` unreachable -> SKIP (the upstream contract check
+  will already FAIL on this; no need to double-fail).
+- All sampled repos have ``dbCategory=None`` -> SKIP with rationale.
+  The column has not been backfilled for these repos so there is no
+  DB ground truth to compare against.
+- Any sampled repo's category-list is empty AND its ``dbCategory`` is
+  non-null -> FAIL (the row has been backfilled but the detail cache
+  shows no junction rows -- a real divergence).
+- Any mismatch -> FAIL with the offending slugs in the detail.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from typing import Any
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+
+# Sample size kept small so the check stays well under the audit's
+# minute-budget. Each sampled repo costs one ``/repos/<slug>`` request.
+SAMPLE_SIZE = 15
+
+# A deterministic-but-distributed seed: same audit run produces the same
+# sample (so a flaky failure can be reproduced) but different runs see
+# different windows (so a hot-cached subset doesn't mask a cold-cache
+# regression). The seed is reset per call so unit tests can pin it.
+DEFAULT_SAMPLE_SEED = 0xCAFE
+
+
+def _candidate_repos(repos: list[dict]) -> list[dict]:
+    """Return repos that have both ``name`` and a non-null ``dbCategory``.
+
+    Repos with ``dbCategory=None`` cannot serve as ground truth -- the
+    column was never backfilled for them. They contribute to the SKIP
+    rationale, not to a FAIL.
+    """
+    candidates = []
+    for repo in repos:
+        name = repo.get("name")
+        db_cat = repo.get("dbCategory")
+        if not name or not db_cat:
+            continue
+        candidates.append({"name": name, "dbCategory": db_cat})
+    return candidates
+
+
+def _detail_category_names(detail: dict) -> list[str]:
+    """Extract the list of ``category_name`` strings from a /repos/<slug>
+    response, tolerating both list-of-dicts (new shape) and list-of-strings
+    (legacy shape) for ``categories``."""
+    cats = detail.get("categories") or []
+    names: list[str] = []
+    for c in cats:
+        if isinstance(c, dict):
+            name = c.get("category_name")
+            if isinstance(name, str) and name:
+                names.append(name)
+        elif isinstance(c, str) and c:
+            names.append(c)
+    return names
+
+
+async def check_cache_consistency(
+    api_url: str,
+    *,
+    sample_size: int = SAMPLE_SIZE,
+    sample_seed: int | None = DEFAULT_SAMPLE_SEED,
+    client: httpx.AsyncClient | None = None,
+) -> list[dict[str, Any]]:
+    """Verify that ``/repos/<slug>`` and ``/library/full`` agree on
+    primary category for a sample of repos.
+
+    Args:
+        api_url: Base URL of the live API deployment.
+        sample_size: Max number of repos to probe with /repos/<slug>.
+        sample_seed: RNG seed for reproducible sampling. Pass ``None``
+            to use system entropy.
+        client: Optional pre-built httpx.AsyncClient (used by tests so
+            ``respx.mock`` can intercept). If ``None``, a fresh client
+            with a 30s timeout is created and closed inside this call.
+
+    Returns:
+        A single-element list of result dicts, matching the convention
+        of the other audit checks.
+    """
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=30)
+
+    try:
+        # 1. Pull /library/full. The frontend pulls page_size=200 so
+        # this is a reasonable production-shaped sample window.
+        try:
+            r = await client.get(f"{api_url}/library/full", params={"page": 1, "page_size": 200})
+            if r.status_code != 200:
+                return [{
+                    "check": "cache vs db: repo detail consistency",
+                    "status": "SKIP",
+                    "detail": (
+                        f"/library/full returned HTTP {r.status_code}; cannot establish "
+                        "DB ground truth -- skipping (the contract check covers reachability)"
+                    ),
+                }]
+            payload = r.json()
+        except Exception as e:
+            return [{
+                "check": "cache vs db: repo detail consistency",
+                "status": "SKIP",
+                "detail": f"/library/full unreachable: {str(e)[:120]}",
+            }]
+
+        repos = payload.get("repos") or []
+        if not repos:
+            return [{
+                "check": "cache vs db: repo detail consistency",
+                "status": "SKIP",
+                "detail": "/library/full returned no repos -- cannot sample",
+            }]
+
+        candidates = _candidate_repos(repos)
+        if not candidates:
+            return [{
+                "check": "cache vs db: repo detail consistency",
+                "status": "SKIP",
+                "detail": (
+                    f"None of {len(repos)} repos in /library/full page 1 have a non-null "
+                    "dbCategory column; cannot establish DB ground truth. The "
+                    "primary_category column backfill (api#444/#445) may still be "
+                    "in flight."
+                ),
+            }]
+
+        # 2. Sample. Cap at sample_size, but never sample more than what's
+        # available.
+        rng = random.Random(sample_seed)
+        n = min(sample_size, len(candidates))
+        sample = rng.sample(candidates, n)
+
+        # 3. For each sampled repo, fetch /repos/<slug> and verify the
+        # dbCategory shows up in the junction-derived categories array.
+        mismatches: list[str] = []
+        unreachable: list[str] = []
+
+        for entry in sample:
+            slug = entry["name"]
+            db_cat = entry["dbCategory"]
+            try:
+                rr = await client.get(f"{api_url}/repos/{slug}")
+                if rr.status_code != 200:
+                    unreachable.append(f"{slug} (HTTP {rr.status_code})")
+                    continue
+                detail = rr.json()
+            except Exception as e:  # network, JSON decode
+                unreachable.append(f"{slug} ({str(e)[:60]})")
+                continue
+
+            detail_cats = _detail_category_names(detail)
+            if db_cat not in detail_cats:
+                # The DB column says X but the cached junction array
+                # doesn't contain X. This is the staleness / drift signal.
+                mismatches.append(
+                    f"{slug}: dbCategory={db_cat!r} not in /repos/<slug> categories={detail_cats!r}"
+                )
+
+        # 4. Score.
+        if unreachable and not mismatches:
+            # Treat upstream-unreachable as SKIP for THIS check -- the
+            # /repos/<slug> reachability is already covered by the
+            # ``reporium-api /repos`` check. We only fail here on a real
+            # consistency violation.
+            return [{
+                "check": "cache vs db: repo detail consistency",
+                "status": "SKIP",
+                "detail": (
+                    f"sampled {n} repos; {len(unreachable)} /repos/<slug> requests failed "
+                    f"-- cannot evaluate consistency. Examples: {unreachable[:3]}"
+                ),
+            }]
+
+        if mismatches:
+            return [{
+                "check": "cache vs db: repo detail consistency",
+                "status": "FAIL",
+                "detail": (
+                    f"{len(mismatches)}/{n} sampled repos have stale or divergent caches: "
+                    f"{mismatches[:5]}"
+                ),
+            }]
+
+        return [{
+            "check": "cache vs db: repo detail consistency",
+            "status": "PASS",
+            "detail": (
+                f"{n}/{n} sampled repos have /repos/<slug> categories that include "
+                f"the /library/full dbCategory column value"
+            ),
+        }]
+    finally:
+        if owns_client:
+            await client.aclose()

--- a/tests/test_cache_consistency.py
+++ b/tests/test_cache_consistency.py
@@ -1,0 +1,246 @@
+"""Tests for the cache-vs-DB consistency invariant.
+
+Pins the regression caught by memory entry 4931 (2026-04-26): an admin
+backfill writes the ``repos.primary_category`` column but the per-slug
+``/repos/<slug>`` Redis cache is not invalidated, so the API serves a
+junction snapshot that disagrees with the column for up to one TTL
+window.
+
+The invariant compares ``/library/full``'s ``dbCategory`` (raw column,
+the closest thing the audit has to DB ground truth without Cloud SQL
+private-IP access) against ``/repos/<slug>``'s ``categories`` array.
+A mismatch is FAIL; an unsamplable corpus is SKIP; a clean sample is
+PASS.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from reporium_audit.checks.cache_consistency import (
+    DEFAULT_SAMPLE_SEED,
+    check_cache_consistency,
+)
+
+
+API_URL = "https://api.example.test"
+LIBRARY_FULL_URL = f"{API_URL}/library/full"
+
+
+def _library_repo(name: str, *, primary_category: str | None, db_category: str | None) -> dict:
+    """Shape mirrors the production /library/full response shape -- only
+    the fields this check reads are populated."""
+    return {
+        "name": name,
+        "primaryCategory": primary_category or "Uncategorized",
+        "dbCategory": db_category,
+        "allCategories": [primary_category] if primary_category else [],
+    }
+
+
+def _detail_response(slug: str, category_names: list[str], *, with_is_primary: bool = True) -> dict:
+    """Shape mirrors /repos/<slug> -- ``categories`` is a list of dicts
+    with ``category_name``/``is_primary``."""
+    return {
+        "name": slug,
+        "owner": "perditioinc",
+        "categories": [
+            {
+                "category_id": cn.lower().replace(" ", "-").replace("&", "and"),
+                "category_name": cn,
+                "is_primary": with_is_primary and i == 0,
+            }
+            for i, cn in enumerate(category_names)
+        ],
+        "allCategories": category_names,
+    }
+
+
+def _row(results: list[dict]) -> dict:
+    """The check returns exactly one result row."""
+    assert len(results) == 1, f"expected one result row, got {results}"
+    return results[0]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_pass_when_dbcategory_present_in_detail_categories():
+    """Clean cache: every sampled repo's dbCategory is also in its
+    /repos/<slug> junction array."""
+    repos = [
+        _library_repo(f"repo-{i}", primary_category="Dev Tools & Automation",
+                      db_category="Dev Tools & Automation")
+        for i in range(20)
+    ]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+    for i in range(20):
+        respx.get(f"{API_URL}/repos/repo-{i}").mock(
+            return_value=httpx.Response(200, json=_detail_response(
+                f"repo-{i}", ["Dev Tools & Automation"]
+            ))
+        )
+
+    results = await check_cache_consistency(API_URL, sample_size=10)
+
+    row = _row(results)
+    assert row["status"] == "PASS", row
+    assert "10/10" in row["detail"] or "10 sampled repos" in row["detail"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fail_when_detail_categories_missing_dbcategory():
+    """Stale cache: /library/full says dbCategory=AI Agents but the
+    cached /repos/<slug> still shows the pre-backfill list."""
+    repos = [
+        _library_repo("stale-1", primary_category="AI Agents", db_category="AI Agents"),
+        _library_repo("fresh-1", primary_category="RAG & Retrieval",
+                      db_category="RAG & Retrieval"),
+    ]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+    # stale-1: dbCategory="AI Agents" but cached detail says "Dev Tools"
+    respx.get(f"{API_URL}/repos/stale-1").mock(
+        return_value=httpx.Response(200, json=_detail_response(
+            "stale-1", ["Dev Tools & Automation"]
+        ))
+    )
+    # fresh-1: cache is consistent with dbCategory
+    respx.get(f"{API_URL}/repos/fresh-1").mock(
+        return_value=httpx.Response(200, json=_detail_response(
+            "fresh-1", ["RAG & Retrieval"]
+        ))
+    )
+
+    results = await check_cache_consistency(API_URL, sample_size=2, sample_seed=42)
+
+    row = _row(results)
+    assert row["status"] == "FAIL", row
+    assert "stale-1" in row["detail"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fail_when_detail_categories_empty_but_db_has_value():
+    """The 2026-04-26 build-your-own-x case: /library/full has a
+    primaryCategory derived from junction but /repos/<slug> returns
+    categories=[]. dbCategory=None should SKIP (no ground truth) but
+    a non-null dbCategory with empty detail list is the staleness FAIL."""
+    repos = [
+        _library_repo("empty-detail", primary_category="Dev Tools & Automation",
+                      db_category="Dev Tools & Automation"),
+    ]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+    respx.get(f"{API_URL}/repos/empty-detail").mock(
+        return_value=httpx.Response(200, json=_detail_response("empty-detail", []))
+    )
+
+    results = await check_cache_consistency(API_URL, sample_size=5)
+
+    row = _row(results)
+    assert row["status"] == "FAIL", row
+    assert "empty-detail" in row["detail"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_skip_when_no_repo_has_dbcategory():
+    """Pre-backfill state: every repo has dbCategory=None so the audit
+    has no DB-side ground truth to compare against. SKIP, not FAIL --
+    this is a missing-credential / missing-data condition, not a bug."""
+    repos = [
+        _library_repo(f"unbackfilled-{i}", primary_category="Dev Tools & Automation",
+                      db_category=None)
+        for i in range(5)
+    ]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+
+    results = await check_cache_consistency(API_URL, sample_size=10)
+
+    row = _row(results)
+    assert row["status"] == "SKIP", row
+    assert "dbCategory" in row["detail"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_skip_when_library_full_returns_non_200():
+    """/library/full reachability is the contract check's job; if it
+    fails, this check defers (SKIP) rather than double-failing."""
+    respx.get(LIBRARY_FULL_URL).mock(return_value=httpx.Response(503))
+
+    results = await check_cache_consistency(API_URL)
+
+    row = _row(results)
+    assert row["status"] == "SKIP", row
+    assert "503" in row["detail"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_skip_when_library_full_unreachable():
+    """Network error (timeout, DNS) on /library/full also skips."""
+    respx.get(LIBRARY_FULL_URL).mock(side_effect=httpx.ConnectError("dns"))
+
+    results = await check_cache_consistency(API_URL)
+
+    row = _row(results)
+    assert row["status"] == "SKIP", row
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_skip_when_all_detail_requests_fail():
+    """If we cannot reach /repos/<slug> at all, defer to /repos health
+    check rather than spurious-failing this invariant."""
+    repos = [
+        _library_repo(f"r-{i}", primary_category="X", db_category="X")
+        for i in range(3)
+    ]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+    for i in range(3):
+        respx.get(f"{API_URL}/repos/r-{i}").mock(return_value=httpx.Response(500))
+
+    results = await check_cache_consistency(API_URL, sample_size=3)
+
+    row = _row(results)
+    assert row["status"] == "SKIP", row
+    assert "cannot evaluate" in row["detail"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_default_seed_is_reproducible():
+    """Same seed -> same sample order; the failure detail names the
+    same offending slug across repeated runs (so flaky failures
+    are reproducible)."""
+    repos = [
+        _library_repo(f"r-{i}", primary_category="A", db_category="A")
+        for i in range(20)
+    ]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+    # Make every detail mismatch so we get a populated FAIL detail.
+    for i in range(20):
+        respx.get(f"{API_URL}/repos/r-{i}").mock(
+            return_value=httpx.Response(200, json=_detail_response(f"r-{i}", ["B"]))
+        )
+
+    first = await check_cache_consistency(API_URL, sample_size=5, sample_seed=DEFAULT_SAMPLE_SEED)
+    second = await check_cache_consistency(API_URL, sample_size=5, sample_seed=DEFAULT_SAMPLE_SEED)
+
+    assert first[0]["status"] == "FAIL"
+    assert second[0]["status"] == "FAIL"
+    assert first[0]["detail"] == second[0]["detail"]


### PR DESCRIPTION
## Summary

Adds a new audit invariant `cache vs db: repo detail consistency` that detects the recurring **"DB row updated -> cache not invalidated -> user sees stale"** regression family — most recently captured in memory entry 4931 (2026-04-26) when `POST /admin/backfill/primary_category_column` (api#445) shipped without invalidating the per-slug `repos:detail:<slug>` Redis cache.

The invariant compares two cross-cache views of the same DB row:

- **`/library/full`'s `dbCategory`** — raw `repos.primary_category` column. This is the closest thing the audit runner has to "raw row state" without DB access (Cloud SQL is private-IP per `reference_cloud_sql_private_ip.md`, so direct DB connections from the audit host are not possible).
- **`/repos/<slug>`'s `categories` array** — `repo_categories` junction table, served from a separate Redis cache with its own TTL.

For 15 sampled repos (deterministic seed by default), the invariant passes when each sample's `dbCategory` value appears as a `category_name` in the detail-page categories array. A mismatch is FAIL with the offending slugs in the detail; an empty/missing ground-truth corpus is SKIP.

The same check is also load-bearing for the column-vs-junction drift family caught by api#444 / #445 — both bugs surface as the same divergence.

## Score map

| Condition | Status |
|---|---|
| Every sampled repo's `dbCategory` is in `/repos/<slug>` categories | PASS |
| Any sampled repo has `dbCategory` not present in detail categories | FAIL (lists offenders) |
| `/library/full` unreachable / non-200 | SKIP (contract check covers reachability) |
| All sampled repos have `dbCategory=None` | SKIP (no DB ground truth) |
| All `/repos/<slug>` requests fail | SKIP (`/repos` health check covers this) |

The SKIP biases are intentional: this invariant only goes red when there is a **real consistency violation**, not when an unrelated upstream is unhealthy.

## Live smoke (2026-04-27)

```
PASS: cache vs db: repo detail consistency
  detail: 15/15 sampled repos have /repos/<slug> categories that include
  the /library/full dbCategory column value
```

Suite-level totals **26/32 -> 27/33** today (PASS).
Would be **26/33** on a fresh pre-backfill deploy (SKIP).

## Test plan

- [x] 8 new unit tests in `tests/test_cache_consistency.py` cover PASS, FAIL (mismatch + empty-detail), SKIP (no-`dbCategory` corpus, HTTP 503, ConnectError, all-detail-fail), reproducibility under fixed seed.
- [x] Full audit suite test count: 31 -> 39, all green.
- [x] `ruff check` clean on new files.
- [x] Live smoke against `https://reporium-api-573778300586.us-central1.run.app` returns PASS.
- [x] Wired into `__main__.run_audit` `asyncio.gather` batch; the check function catches network/JSON exceptions and returns a SKIP row rather than raising (so a failure inside this check cannot abort the audit, matching the runner-survival contract pinned by knowledge_graph_wiring tests).

Refs:
- KAN-AUDIT-INVARIANT-CACHE
- mem 4931 (`Backfill does not invalidate repos:detail cache, may be serving stale data`)
- `project_dq_gate_column_vs_junction_bug.md` (api#444 / #445 — same family of bugs)
- `reference_cloud_sql_private_ip.md` (why we cannot reach the DB directly)

Do **not** merge — operator review required (per ticket constraints).