### PR TITLE
ci: add PR-trigger workflow for unit tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,34 @@
+name: PR
+
+on:
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs on the same PR when a new commit is pushed.
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Unit tests (Python 3.11)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
+
+      # Unit tests only. All HTTP-touching tests use respx.mock so this
+      # job does NOT hit any live URL (no REPORIUM_API_URL, no GH_TOKEN).
+      # The nightly audit (audit.yml) is the only workflow that probes
+      # live infrastructure.
+      - name: Run unit tests
+        run: pytest tests/ -v


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pr.yml` so pull requests against `main` actually run CI. The KAN-CI-WATCH sweep flagged this repo as having no `on: pull_request` workflow — recent PR #15 (cache_consistency invariant + 8 unit tests) shipped with an empty `statusCheckRollup`, which means regressions could land silently on `main`.

- **Trigger:** `pull_request` against `main`.
- **Runner:** `ubuntu-latest`, Python 3.11.
- **Install:** `pip install -e ".[dev]"` (matches `pyproject.toml` `[project.optional-dependencies].dev`: pytest, pytest-asyncio, respx, ruff).
- **Command:** `pytest tests/ -v`.
- **Concurrency:** in-progress runs on the same PR are cancelled when a new commit is pushed (`cancel-in-progress: true`).

## No live URLs

The new workflow runs **unit tests only** and does **not** hit any live URL:

- All HTTP-touching tests use `@respx.mock` (`test_contract.py`, `test_workflows.py`, `test_leaks.py`, `test_cloud_run_tags.py` — verified via grep).
- `test_reporter.py` and `test_knowledge_graph_wiring.py` make no HTTP calls at all.
- The job exposes **no** `REPORIUM_API_URL` or `GH_TOKEN` env vars (compare to `audit.yml`).
- The nightly `audit.yml` (cron `0 8 * * *`) is **untouched** and remains the only workflow that probes live infrastructure.

## Verification

- Locally ran `pytest tests/ -q` on this branch: **31 passed in 2.55s** (PR #15's +8 tests will land separately).
- `permissions: contents: read` only — workflow can't write to the repo.

## Note on this PR

This workflow file was added to the branch in a single commit, but the workflow trigger is `on: pull_request` — it won't run on its own PR (the workflow YAML doesn't exist on `main` yet). It will start running on the **next** PR opened against `main` after this one merges. The merge of this PR itself is therefore a manual judgment call against the workflow YAML.

Refs: KAN-CI-WIREUP / KAN-CI-WATCH.

DO NOT merge automatically.