### PR TITLE
KAN-171: SHA-pin GitHub Actions in reporium-audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,9 +16,9 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,9 +17,9 @@ jobs:
     name: Unit tests (Python 3.11)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,10 +12,10 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 20
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
       - run: pip install git+https://github.com/perditioinc/reporium-security.git


### PR DESCRIPTION
## Summary

Replaces external `uses: <action>@<vN>` references in `.github/workflows/` with full 40-character commit SHAs + version comments, eliminating supply-chain risk from mutable tags. Mirrors the [KAN-163 pattern from reporium-ingestion (PR #75)](https://github.com/perditioinc/reporium-ingestion/pull/75).

Implements **KAN-171** (KAN-163 follow-up).

## Pins applied

| Action | Was | Now (SHA) | Comment |
|---|---|---|---|
| `actions/checkout` | `@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2) | `@34e114876b0b11c390a56381ad16ebd13914f8d5` | `# v4.3.1` |
| `actions/setup-python` | `@v5` | `@a26af69be951a213d495a4c3e4e4022e16d87065` | `# v5.6.0` |

## Files changed

- `.github/workflows/audit.yml` — pins both actions
- `.github/workflows/pr.yml` — pins both actions
- `.github/workflows/security.yml` — pins both actions

## Notes

- All SHAs verified via `gh api repos/<owner>/<repo>/git/commits/<sha>`.
- No workflow logic changes; only `uses:` pinning and a v4.2.2 -> v4.3.1 normalization (matches KAN-163).
- No internal reusable workflows in this repo.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(...)"` for all 3 files — parse cleanly
- [x] `grep -E "uses:.*@v[0-9]"` returns zero matches across `.github/workflows/`
- [ ] PR workflow runs on this PR and stays green