### PR TITLE
test: pin lazy psycopg2 import, cron-masking, and private-fork guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
 .pytest_cache/
 __pycache__/
 *.egg-info/
+
+# Data artifacts pulled/generated during audit runs -- never commit these.
+# library_full.json is a full dump of /library/full (can contain the entire
+# catalog incl. private-classification fields); latency-*.json are probe
+# timing dumps. Keep them local.
+library_full.json
+latency-*.json
+data/
+snapshot/
+checkpoints/
+
+# Local audit scratch output (dated operator packs committed under .audit/
+# are tracked deliberately; this ignores ad-hoc local exports written there).
+.audit/tmp/
+.audit/*.local.md

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -118,6 +118,33 @@ async def test_clean_public_originals_pass():
     assert leak_row["status"] == "PASS"
 
 
+@pytest.mark.asyncio
+@respx.mock
+async def test_private_fork_still_fails():
+    """The 2026-04-26 fix decoupled ``isFork`` from privacy -- but it must not
+    swing the other way and let a fork that is ALSO private leak through.
+
+    A private repo that happens to be a fork is still a private-exposure
+    failure. Privacy classification keys on ``isPrivate``/``is_private``
+    only; ``isFork`` must neither trigger nor suppress the leak row.
+    """
+    repos = [
+        _repo("public-fork", is_fork=True),
+        _repo("private-fork", is_fork=True, privacy="private"),
+    ]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+
+    results = await check_contract(API_URL)
+
+    leak_row = _row_named(results, "no private repos exposed")
+    assert leak_row["status"] == "FAIL"
+    assert "private-fork" in leak_row["detail"]
+    # The public fork must NOT be listed as a leak.
+    assert "public-fork" not in leak_row["detail"]
+
+
 # ---------------------------------------------------------------------------
 # Private-exposure detection — both naming conventions, both rows
 # ---------------------------------------------------------------------------

--- a/tests/test_knowledge_graph_deferred_import.py
+++ b/tests/test_knowledge_graph_deferred_import.py
@@ -1,0 +1,119 @@
+"""Tests pinning the lazy ``psycopg2`` import in the knowledge-graph check.
+
+History (issue #13): ``psycopg2`` is intentionally NOT a declared dependency
+of reporium-audit -- the runner's only hard deps are ``httpx`` and
+``python-dotenv``. ``psycopg2`` is needed *only* when ``DATABASE_URL`` is set,
+so the import lives inside ``check_knowledge_graph`` rather than at module top
+level. These tests prove that contract two ways:
+
+  1. The module imports, and the no-DB SKIP path runs, with ``psycopg2``
+     completely unavailable -- a top-level ``import psycopg2`` would make
+     even importing the module explode on a stock audit runner.
+  2. When ``DATABASE_URL`` *is* set but ``psycopg2`` is missing, the check
+     degrades to a clean FAIL row (not an uncaught ImportError).
+
+To make the tests deterministic regardless of whether ``psycopg2`` happens
+to be installed in the test venv, we force its absence via a context manager
+that blocks the import (``sys.modules[name] = None`` makes ``import name``
+raise ImportError, mirroring a runner that never installed the dep).
+"""
+
+from __future__ import annotations
+
+import builtins
+import contextlib
+import importlib
+import sys
+
+import pytest
+
+
+@contextlib.contextmanager
+def _psycopg2_unavailable():
+    """Force ``import psycopg2`` (and submodules) to raise ImportError.
+
+    Restores the original import state on exit so the absence does not leak
+    into other tests in the session.
+    """
+    blocked_prefix = "psycopg2"
+    saved = {
+        name: mod
+        for name, mod in list(sys.modules.items())
+        if name == blocked_prefix or name.startswith(blocked_prefix + ".")
+    }
+    for name in saved:
+        del sys.modules[name]
+    # A None entry in sys.modules makes `import psycopg2` raise ImportError.
+    sys.modules[blocked_prefix] = None  # type: ignore[assignment]
+
+    real_import = builtins.__import__
+
+    def _guarded_import(name, *args, **kwargs):
+        if name == blocked_prefix or name.startswith(blocked_prefix + "."):
+            raise ImportError(f"No module named '{name}'")
+        return real_import(name, *args, **kwargs)
+
+    builtins.__import__ = _guarded_import
+    try:
+        yield
+    finally:
+        builtins.__import__ = real_import
+        sys.modules.pop(blocked_prefix, None)
+        sys.modules.update(saved)
+
+
+def test_module_imports_without_psycopg2():
+    """Importing the check module must not require ``psycopg2``.
+
+    A regression to a top-level ``import psycopg2`` would raise here, on a
+    fresh import of the module while psycopg2 is unavailable.
+    """
+    with _psycopg2_unavailable():
+        sys.modules.pop("reporium_audit.checks.knowledge_graph", None)
+        mod = importlib.import_module("reporium_audit.checks.knowledge_graph")
+        assert hasattr(mod, "check_knowledge_graph")
+
+
+@pytest.mark.asyncio
+async def test_skip_path_never_touches_psycopg2():
+    """The empty-DATABASE_URL SKIP path must run with psycopg2 absent.
+
+    This is the audit-CI default (no DB credentials). It must SKIP, not
+    FAIL, and must not depend on psycopg2 being importable.
+    """
+    with _psycopg2_unavailable():
+        sys.modules.pop("reporium_audit.checks.knowledge_graph", None)
+        mod = importlib.import_module("reporium_audit.checks.knowledge_graph")
+        results = await mod.check_knowledge_graph("")
+
+    assert len(results) == 1
+    assert results[0]["status"] == "SKIP"
+    assert "DATABASE_URL" in results[0]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_configured_db_without_psycopg2_fails_cleanly():
+    """DATABASE_URL set but psycopg2 missing -> a clean FAIL row, not a crash.
+
+    The lazy import is wrapped in try/except ImportError so a runner that
+    sets DATABASE_URL but forgot to install psycopg2 gets an actionable
+    audit row rather than an uncaught traceback that aborts the whole run.
+    """
+    with _psycopg2_unavailable():
+        sys.modules.pop("reporium_audit.checks.knowledge_graph", None)
+        mod = importlib.import_module("reporium_audit.checks.knowledge_graph")
+        results = await mod.check_knowledge_graph(
+            "postgresql://user:pw@localhost:5432/db"
+        )
+
+    assert len(results) == 1
+    row = results[0]
+    assert row["status"] == "FAIL"
+    assert "psycopg2" in row["detail"]
+
+
+def teardown_module(module):
+    """Re-import the module under normal conditions so later test files in
+    the same session get the unguarded version back in sys.modules."""
+    sys.modules.pop("reporium_audit.checks.knowledge_graph", None)
+    importlib.import_module("reporium_audit.checks.knowledge_graph")

--- a/tests/test_workflows_masking.py
+++ b/tests/test_workflows_masking.py
@@ -1,0 +1,176 @@
+"""Regression test for the cron-masked-by-dispatch failure mode.
+
+The documented 2026-04-23 incident: a repo's *latest* workflow run was a
+green ``workflow_dispatch`` (someone re-ran CI manually), so the
+latest-run-only smoke test (``check_workflows``) reported PASS -- while the
+nightly scheduled run (``Data Quality Check``) had been red for days.
+
+``check_scheduled_workflows`` exists precisely to catch this. This test
+exercises the two checks against the SAME synthetic GitHub API payload and
+asserts the contrast directly:
+
+  - ``check_workflows`` -> PASS for reporium-api (sees only the latest run)
+  - ``check_scheduled_workflows`` -> FAIL for the Data Quality Check row
+    (filters by workflow name and finds the red scheduled run)
+
+If the scheduled check ever regresses to "latest run only" it would also
+go green here, and this test would fail -- which is the point.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from reporium_audit.checks.workflows import (
+    REPOS,
+    SCHEDULED_WORKFLOWS,
+    check_scheduled_workflows,
+    check_workflows,
+)
+
+# The repo whose scheduled job is red but whose latest run is a green
+# manual dispatch. Pulled from the real config so the test tracks the
+# actual (repo, workflow) pair the audit defends.
+MASKED_REPO = "perditioinc/reporium-api"
+MASKED_WORKFLOW = "Data Quality Check"
+
+
+def _runs_payload_with_masked_cron(workflow_name: str) -> dict:
+    """A workflow_runs page where:
+
+    - index 0 is the NEWEST run: a passing ``workflow_dispatch`` of CI,
+    - a later entry is the scheduled ``workflow_name`` run, and it FAILED.
+
+    This is the exact shape that fools a latest-run-only check.
+    """
+    return {
+        "workflow_runs": [
+            {
+                "name": "CI",
+                "event": "workflow_dispatch",
+                "conclusion": "success",
+                "run_started_at": "2026-04-25T18:00:00Z",
+            },
+            {
+                "name": "CI",
+                "event": "push",
+                "conclusion": "success",
+                "run_started_at": "2026-04-25T12:00:00Z",
+            },
+            {
+                "name": workflow_name,
+                "event": "schedule",
+                "conclusion": "failure",
+                "run_started_at": "2026-04-23T06:00:00Z",
+            },
+        ]
+    }
+
+
+def _all_green_payload(workflow_name: str) -> dict:
+    """A page whose scheduled run is green (for the non-masked repos)."""
+    return {
+        "workflow_runs": [
+            {
+                "name": workflow_name,
+                "event": "schedule",
+                "conclusion": "success",
+                "run_started_at": "2026-04-25T06:00:00Z",
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_red_cron_masked_by_green_dispatch_is_caught():
+    """The masked-cron scenario: latest-run check passes, scheduled check fails."""
+    # Mock the scheduled-workflow endpoint (per_page=30) for each tracked
+    # scheduled pair. Only reporium-api's Data Quality Check is masked-red.
+    for repo, workflow_name in SCHEDULED_WORKFLOWS:
+        if repo == MASKED_REPO and workflow_name == MASKED_WORKFLOW:
+            payload = _runs_payload_with_masked_cron(workflow_name)
+        else:
+            payload = _all_green_payload(workflow_name)
+        respx.get(
+            f"https://api.github.com/repos/{repo}/actions/runs"
+        ).mock(return_value=httpx.Response(200, json=payload))
+
+    # Mock the latest-run smoke endpoint (per_page=1) for every repo. The
+    # masked repo returns its newest run = the green dispatch.
+    for repo in REPOS:
+        if repo == MASKED_REPO:
+            latest = _runs_payload_with_masked_cron(MASKED_WORKFLOW)
+            latest = {"workflow_runs": latest["workflow_runs"][:1]}
+        else:
+            latest = {"workflow_runs": [{"name": "CI", "conclusion": "success"}]}
+        respx.get(
+            f"https://api.github.com/repos/{repo}/actions/runs",
+            params={"per_page": "1"},
+        ).mock(return_value=httpx.Response(200, json=latest))
+
+    smoke = await check_workflows("fake-token")
+    scheduled = await check_scheduled_workflows("fake-token")
+
+    smoke_by_name = {r["check"]: r for r in smoke}
+    sched_by_name = {r["check"]: r for r in scheduled}
+
+    # The smoke test is fooled: reporium-api's latest run is the green dispatch.
+    api_smoke = smoke_by_name["reporium-api CI"]
+    assert api_smoke["status"] == "PASS", (
+        f"latest-run smoke test should be masked green, got {api_smoke}"
+    )
+
+    # The scheduled check is NOT fooled: it finds the red Data Quality Check.
+    api_sched = sched_by_name["reporium-api schedule: Data Quality Check"]
+    assert api_sched["status"] == "FAIL", (
+        f"scheduled check must catch the red cron behind the green dispatch, "
+        f"got {api_sched}"
+    )
+    assert "failure" in api_sched["detail"]
+
+    # And the contrast is real: the smoke test did NOT flag this repo as failing.
+    assert api_smoke["status"] != api_sched["status"], (
+        "the whole point is that the two checks disagree for the masked repo"
+    )
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_scheduled_check_picks_newest_matching_run_not_first_entry():
+    """Name-filter must select the scheduled run even when it is not index 0.
+
+    Guards against a naive ``runs[0]`` implementation: the matching scheduled
+    run is buried under newer, unrelated runs.
+    """
+    for repo, workflow_name in SCHEDULED_WORKFLOWS:
+        respx.get(
+            f"https://api.github.com/repos/{repo}/actions/runs"
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "workflow_runs": [
+                        {
+                            "name": "Unrelated Manual Run",
+                            "event": "workflow_dispatch",
+                            "conclusion": "success",
+                            "run_started_at": "2026-04-26T09:00:00Z",
+                        },
+                        {
+                            "name": workflow_name,
+                            "event": "schedule",
+                            "conclusion": "failure",
+                            "run_started_at": "2026-04-25T06:00:00Z",
+                        },
+                    ]
+                },
+            )
+        )
+
+    results = await check_scheduled_workflows("fake-token")
+    # Every scheduled row resolves to its buried red run -> all FAIL.
+    assert all(r["status"] == "FAIL" for r in results), results
+    assert all("failure" in r["detail"] for r in results), results


### PR DESCRIPTION
## What

Additive hardening tests for `reporium-audit`. **No source changes** -- all three checks already behave correctly; these tests pin the behavior so the documented regressions cannot recur silently.

### 1. Lazy `psycopg2` import (`tests/test_knowledge_graph_deferred_import.py`)
`psycopg2` is intentionally **not** a declared dependency (deps are `httpx` + `python-dotenv` only). It is imported lazily inside `check_knowledge_graph`, needed only when `DATABASE_URL` is set. New tests prove:
- the module imports, and the no-DB **SKIP** path runs, with `psycopg2` fully unavailable (the audit-CI default);
- with `DATABASE_URL` set but `psycopg2` missing, the check returns a clean **FAIL** row instead of an uncaught `ImportError`.

Absence is forced via an import guard so the test is deterministic whether or not `psycopg2` is in the venv.

### 2. Cron masked by passing dispatch (`tests/test_workflows_masking.py`)
Pins the documented 2026-04-23 failure mode: a red scheduled run masked by a newer passing `workflow_dispatch`. The test drives `check_workflows` (latest-run smoke -> **PASS**) and `check_scheduled_workflows` (name-filtered -> **FAIL**) against the **same** synthetic GitHub Actions payload (mocked with `respx`) and asserts they disagree for the masked repo. A second test buries the red scheduled run under newer unrelated runs to guard against a naive `runs[0]` regression.

### 3. Private fork still leaks (`tests/test_contract.py::test_private_fork_still_fails`)
The 2026-04-26 fork/privacy decoupling must not swing the other way: a repo that is **both** a fork and private is still a private-exposure **FAIL**. `isFork` must neither trigger nor suppress the leak row.

### 4. `.gitignore`
Ignore data artifacts (`library_full.json`, `latency-*.json`, `data/`, `snapshot/`, `checkpoints/`) so dumps are never committed.

## Verification

All new assertions verified **non-tautological** via source mutation -- each test fails when its target invariant is broken (top-level `import psycopg2`; scheduled check regressed to `runs[0]`; classification letting a fork suppress the private signal), then passes again once reverted.

**Test command:** `uv run pytest -q`

**Real output tail:**
```
.......................................................                  [100%]
55 passed in 5.41s
```

(49 -> 55: +6 new tests. Offline -- all infra mocked, no network, no tokens.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)