### PR TITLE
test: psycopg2-missing degradation test (rescued local-only)

### DIFF
--- a/.audit/2026-04-25/audit-hardening-lane-jira.md
+++ b/.audit/2026-04-25/audit-hardening-lane-jira.md
@@ -1,0 +1,117 @@
+# Audit Lane — 2026-04-25 Lane Log
+
+## +3h follow-up: 2026-04-25 ~20:05 PDT
+
+**State changed since 17:03 PDT checkpoint — both PRs merged to `main`.**
+
+| PR | Title | Merged at (UTC) | Merged by | Merge commit | Base |
+|---|---|---|---|---|---|
+| [#12](https://github.com/perditioinc/reporium-audit/pull/12) | feat(audit): harden coverage against live failure modes | 2026-04-26 00:06:50 | kimmymakesmoves | `1002030` | main |
+| [#11](https://github.com/perditioinc/reporium-audit/pull/11) | docs: audit weekly operator pack | 2026-04-26 00:29:07 | kimmymakesmoves | `bfb1366` | main |
+
+`origin/main` HEAD advanced `80d5352` → `1002030` → `bfb1366`. Merge order matches the dependency the docs PR called out (hardening checks land before the operator guide that references them), so the post-merge tree is internally consistent.
+
+### Step 6 cross-check — operator guide vs. shipped checks on `origin/main`
+
+Walked every check name referenced in `docs/OPERATOR_GUIDE.md` against `reporium_audit/checks/` on `bfb1366`:
+
+| Reference in guide | Shipped check name | Source |
+|---|---|---|
+| `reporium-api /health`, `/repos`, `/search` | identical | `checks/api.py:18,32,45` |
+| `contract: no private/fork repos exposed` | identical | `checks/contract.py:39` |
+| `knowledge graph build freshness` (>25h FAIL) | identical | `checks/knowledge_graph.py:97,107,116` |
+| `knowledge graph DEPENDS_ON > 0` | identical | `checks/knowledge_graph.py:126` |
+| `knowledge graph edge count regression` (>50% / >20%) | identical | `checks/knowledge_graph.py:134,167,173,182` |
+| `cloud run candidate tags` | identical | `checks/cloud_run_tags.py:122,130,143,153,162,204` |
+| `reporium-db index.json fresh`, `reporium-db repo count` | identical | `checks/reporium_db.py:28,39,45` |
+| `leaks: <repo> README` | identical | `checks/leaks.py:85` |
+| `<repo> schedule: <workflow>` | identical | `checks/workflows.py:122` |
+| `<repo> CI` | identical | `checks/workflows.py:80` |
+
+No dangling references — the docs PR's pre-merge "strip dangling refs to unshipped checks/reporter" commit did its job. Operator guide is in sync with shipped check vocabulary; no follow-up edit needed from this lane.
+
+### Action taken
+
+- Created this lane log with merge facts and the §6 cross-check.
+- Posted a brief post-merge confirmation comment on PRs #11 and #12 naming the merge commit and what was verified.
+- No code changes to `reporium_audit/**` or `tests/**` (none warranted).
+- Did not push this lane log to remote — it's a local audit-trail artifact for this autonomous run; promoting it to `main` is the operator's call.
+
+### Residual / next checkpoint
+
+The +8h checkpoint (`audit-lane-followup-plus8h-2026-04-26-am`, 01:03 PDT) is still scheduled to run. By that time:
+- Tonight's nightly audit (~01:05 PDT cron, 08:05 UTC) should land a `audit: nightly report 2026-04-26` commit on `main`. If it doesn't, that's the §5 signal #6 ("nightly commit missing entirely") and the +8h run should investigate.
+- The newly-wired `cloud run candidate tags`, `leaks: …`, `knowledge graph build freshness`, and per-(repo, workflow-name) schedule checks will be exercised for the first time on a real CI run. Expect either new SKIPs (if `GH_TOKEN` / `DATABASE_URL` aren't on the runner) or the first real signal from each.
+
+---
+
+## +8h pre-morning final: 2026-04-26 ~01:03 PDT (08:03 UTC + nightly fired at 08:46 UTC)
+
+**Status changed since +3h: nightly audit FIRED but FAILED.** No `2026-04-26` report was committed to `main`. Root cause is a missing-dep regression in PR #12. Auto-filed alarm landed.
+
+### PR state (post-merge, both unchanged)
+| PR | State | Merged at (UTC) | Merge commit |
+|---|---|---|---|
+| [#11](https://github.com/perditioinc/reporium-audit/pull/11) | MERGED | 2026-04-26 00:29:07 | `bfb1366` |
+| [#12](https://github.com/perditioinc/reporium-audit/pull/12) | MERGED | 2026-04-26 00:06:50 | `1002030` |
+
+`origin/main` HEAD = `bfb1366` (no advance since +3h — nightly never reached its commit step).
+
+### Nightly audit run — FIRST RED ON HARDENED CODE
+| Field | Value |
+|---|---|
+| Workflow | Nightly Audit |
+| Run | [`24952565529`](https://github.com/perditioinc/reporium-audit/actions/runs/24952565529) |
+| Started | 2026-04-26 08:46:21 UTC (~01:46 PDT — ~41 min late vs. `cron: '0 8 * * *'` due to GH scheduler drift, normal) |
+| Duration | 12s |
+| Conclusion | **failure** |
+| Auto-filed issue | [#13 "Audit failure 2026-04-26"](https://github.com/perditioinc/reporium-audit/issues/13), opened 08:46:31 UTC |
+
+### Failure root cause
+Step "Run audit" (`python -m reporium_audit run`) crashed at import time:
+
+```
+File ".../reporium_audit/__main__.py", line 15, in <module>
+    from reporium_audit.checks.knowledge_graph import check_knowledge_graph
+File ".../reporium_audit/checks/knowledge_graph.py", line 24, in <module>
+    import psycopg2
+ModuleNotFoundError: No module named 'psycopg2'
+```
+
+This is a **regression from PR #12**. `reporium_audit/checks/knowledge_graph.py:24` introduced a module-top-level `import psycopg2`, but:
+- `pyproject.toml` `[project] dependencies` lists only `httpx>=0.27` and `python-dotenv>=1.0`. Neither `psycopg2` nor `psycopg2-binary` is declared (runtime or `dev`).
+- `.github/workflows/audit.yml:25` installs with bare `pip install -e .` — pulls only declared deps.
+- The check **was designed** to skip cleanly when `DATABASE_URL` is unset (per `checks/knowledge_graph.py:97,107,116,126,134,167,173,182` referenced in §6 cross-check above), but the top-level import means the module never finishes loading on a runner without psycopg2 — skip logic never gets a chance to run.
+
+Local `pytest -q` continued passing on `824cab69` because the developer venv has psycopg2 from another project; CI does not.
+
+### Disposition for the 2026-04-26 morning operator
+**Pick one of two fixes (both single-PR, both in scope for `reporium-audit`):**
+
+1. **Add the dep** — append `"psycopg2-binary>=2.9"` to `pyproject.toml` `[project] dependencies`. One line. Pragmatic. Matches the spirit of "the check needs the driver to function." Issue: now every install pulls libpq even when `DATABASE_URL` isn't set.
+2. **Move the import inside `check_knowledge_graph()`** (or guard with a `try/except ImportError`). Preserves the skip-when-env-missing contract that other checks already follow. Slightly more code but architecturally consistent.
+
+Recommendation from this lane: **option 2** is the more honest fix because the *contract* the file already implements (skip when no `DATABASE_URL`) is broken by a top-level import that mandates the driver regardless of env. Either is acceptable; option 1 is faster.
+
+After the fix lands, manually re-run via `gh workflow run audit.yml --repo perditioinc/reporium-audit` to seed the missing 2026-04-26 row, OR let the next 08:00 UTC fire (2026-04-27) catch up — the `commit_only_on_diff` step will still create that day's row.
+
+### Residual blind spots from morning note — re-evaluated
+- ❌ "Cloud run candidate tags / leaks: … / knowledge graph build freshness / per-(repo, workflow-name) schedule" first-real-run signal — **NOT YET OBSERVED**: the run died at module import, before any of these checks executed. They remain unverified end-to-end on CI. Will be exercised on the first nightly *after* the psycopg2 fix.
+- ✅ Operator-guide vs. shipped-checks consistency (§6 cross-check) — still valid; `bfb1366` is unchanged.
+- ✅ Auto-failure issue creation pathway — verified working (#13 filed within 10s of failure).
+
+### Cosmetic noise (informational)
+Both PRs received an "@-" comment from `perditioinc` at 03:05:43 / 03:05:48 UTC. Body is literally `@-`. Looks like a malformed automated post from a different lane. Not blocking, not from this lane. Worth a quick eyeball during the morning sweep.
+
+### Action taken by this lane
+- Appended this +8h block to the lane log.
+- Posted a brief comment on PR #12 referencing run `24952565529`, issue #13, and the root cause.
+- **Did not** edit code, push to `main`, or open a fix PR — that's the morning operator's call (a fix touches `pyproject.toml` or `checks/knowledge_graph.py` and the +8h scope says "do not merge or deploy"; cutting a fresh PR for a 1-line change in the middle of the night without operator awareness is the wrong default).
+- **Did not** push this lane log to remote — same reasoning as the +3h pass; it's a local audit-trail artifact for the operator.
+
+### Final disposition
+**Morning queue, in order of priority:**
+1. Resolve [#13](https://github.com/perditioinc/reporium-audit/issues/13) by adding `psycopg2-binary` dep or moving the import inside the function (recommend the latter).
+2. Manually trigger nightly to seed the 2026-04-26 report row, OR accept the gap.
+3. Re-evaluate the four "first-real-run" checks once a clean nightly succeeds — that's where the *actual* hardening signal will surface.
+4. (Optional cosmetic) Delete the two stray `@-` comments on PRs #11 / #12.

--- a/.audit/2026-04-26/contract-check-fork-conflation-investigation.md
+++ b/.audit/2026-04-26/contract-check-fork-conflation-investigation.md
@@ -1,0 +1,101 @@
+# Audit/privacy contract investigation — 2026-04-26
+
+**Lane:** investigate the audit/privacy "contract failure" hinted at as a live `/repos` (actually `/library/full`) issue.
+**Status:** investigation complete; no PR opened from this lane (lane scope is "investigate", and the operator may want to bundle the two fixes differently).
+
+## TL;DR
+
+- **No actual privacy violation.** Live `/library/full` returns 0 `isPrivate=true` repos out of 200.
+- **The "audit/privacy contract failure" is two stacked bugs in `reporium-audit`, neither in `reporium-api`:**
+  1. **Audit can't run at all** — `psycopg2` import error (issue [#13](https://github.com/perditioinc/reporium-audit/issues/13), already documented in the +8h log).
+  2. **Contract check is misdefined** — [`reporium_audit/checks/contract.py:37`](../../reporium_audit/checks/contract.py:37) flags `isFork OR isPrivate` as a privacy violation. Reporium's curated catalog is forks of upstream open-source repos — that's the product. Once #13 is fixed, this check will FAIL on every clean nightly.
+
+## Live probe results (2026-04-26 ~02:58 PDT / 09:58 UTC)
+
+```
+GET https://reporium-api-573778300586.us-central1.run.app/library/full
+HTTP=200  TIME=1.0s  SIZE=9.8MB
+```
+
+| Field | Value |
+|---|---|
+| `totalRepos` | 200 (single page returned) |
+| `isPrivate=true` count | **0** |
+| `isFork=true` count | **200** |
+| BOTH `isFork && isPrivate` | 0 |
+| Per `contract.py:37` logic | **200/200 = 100% violations** (would FAIL) |
+
+First 5 fork names (sanity check — these are well-known upstream repos, not anything sensitive):
+`build-your-own-x`, `awesome`, `freeCodeCamp`, `public-apis`, `free-programming-books`.
+
+## Where the bug originated
+
+```
+fe9e5621 (perditioinc 2026-03-22 17:33:56 -0700 37)  private = [repo["name"] for repo in repos if repo.get("isFork") or repo.get("isPrivate")]
+fe9e5621 (perditioinc 2026-03-22 17:33:56 -0700 39)  "check": "contract: no private/fork repos exposed",
+fe9e5621 (perditioinc 2026-03-22 17:33:56 -0700 41)  "detail": f"{len(repos)} repos, {len(private)} private/fork" if private else f"{len(repos)} public owned repos",
+```
+
+Commit `fe9e562` from 2026-03-22 introduced the conflation. The detail string `"public owned repos"` suggests the author expected `/library/full` to be an originals-only surface — but the live response shows it has always been a fork-curation surface (or was at least so before the audit ran). The check has been latently wrong for ~5 weeks because the audit hasn't completed cleanly to surface it.
+
+## Why this matters in the broader sweep
+
+The user's framing "the audit failure may indicate a live contract problem on `/repos`" is correct in spirit but the failure surface is **inside the audit's check definition**, not inside the API's response. Specifically:
+
+- `/library/full` is **NOT** leaking private repos (privacy is intact).
+- The audit's notion of "what `/library/full` should return" is **stale / wrong**.
+
+This means: **once #13 is fixed and the audit runs cleanly, the operator will get a false-positive privacy alarm** unless `contract.py:37` is also fixed. The two fixes are coupled in practice.
+
+## Two recommended fixes (both inside `reporium-audit`, both small)
+
+### Fix A — Unblock the audit (issue #13)
+Per the +8h log's recommendation (option 2):
+- Move `import psycopg2` from module-top of `reporium_audit/checks/knowledge_graph.py` line 24 into the body of `check_knowledge_graph()` (or guard with `try/except ImportError`).
+- Preserves the skip-when-`DATABASE_URL`-missing contract that the rest of the file already implements.
+- One file changed, ~5 lines.
+
+### Fix B — Stop conflating fork with private
+In [`reporium_audit/checks/contract.py:37`](../../reporium_audit/checks/contract.py:37):
+
+```python
+# Before
+private = [repo["name"] for repo in repos if repo.get("isFork") or repo.get("isPrivate")]
+results.append({
+    "check": "contract: no private/fork repos exposed",
+    ...
+    "detail": f"{len(repos)} repos, {len(private)} private/fork" if private else f"{len(repos)} public owned repos",
+})
+
+# After
+private = [repo["name"] for repo in repos if repo.get("isPrivate")]
+results.append({
+    "check": "contract: no private repos exposed",
+    "status": "PASS" if len(private) == 0 else "FAIL",
+    "detail": f"{len(repos)} repos, {len(private)} private" if private else f"{len(repos)} public repos",
+})
+```
+
+If the operator genuinely *also* wants a "no forks exposed" check on a different surface (e.g., a future `/library/owned`), that's a separate check on a separate endpoint, not this one. Don't reintroduce the conflation under a renamed banner.
+
+Optional add-on: a regression test fixture that verifies `check_contract` does NOT flag `isFork=true` rows (only `isPrivate=true`). Lives in `tests/test_contract.py`.
+
+## What is explicitly NOT a finding
+
+- ❌ `/library/full` exposing private repos — verified false (0 of 200).
+- ❌ A `reporium-api`-side bug — the API behavior is consistent with product intent (forks are the catalog).
+- ❌ A `reporium-ingestion#67` issue — unrelated; #67 is empty-fork enrichment for the DQ gate denominator.
+
+## Decision on item 4 of the lane plan ("decide whether #67 needs to move")
+
+The audit/privacy investigation does not produce evidence that bumps `#67`'s priority either way. `#67` lives on the DQ enrichment lane, not the audit lane. Its urgency depends on what the +6h post-merge verification of `reporium-api#444` shows about residual `primary_category_coverage` after the column-sync fix + backfill. **Defer the #67 priority decision until after the +6h trigger fires.**
+
+## Exact next action
+
+1. Operator decides which fix lane wants both A and B:
+   - Bundle as one PR (`fix(audit): unblock nightly + stop conflating fork with private`) — coupled in practice anyway.
+   - OR two PRs in order (A first to unblock, B second to prevent false positive).
+2. After landing the fix(es), `gh workflow run audit.yml --repo perditioinc/reporium-audit` to seed the missed 2026-04-26 row and verify both:
+   - the audit completes (no psycopg2 crash)
+   - `contract: no private repos exposed` returns PASS, not FAIL
+3. The +6h scheduled agent (`trig_015qAx1pTpYxfgSCZdqQW9i3`) is independent and continues to track the DQ #444 lane.

--- a/.audit/2026-04-27/audit-nightly-unblock.md
+++ b/.audit/2026-04-27/audit-nightly-unblock.md
@@ -1,0 +1,276 @@
+# Audit Nightly Unblock — handoff
+
+**Date:** 2026-04-27
+**Lane:** Audit Nightly Unblock (close out the issue-#13 + contract-conflation pair)
+**Status:** **code complete on branch + missing-psycopg2 test coverage added** — needs PR + merge.
+**Branch:** `fix/audit-contract-fork-conflation`
+**HEAD:** `e0edcd1 fix(audit): drop fork conflation and lazy-import psycopg2` plus uncommitted test additions in `tests/test_knowledge_graph_wiring.py` (this lane).
+
+## TL;DR
+
+The two-bug pair the 2026-04-26 investigation flagged ([`contract-check-fork-conflation-investigation.md`](../2026-04-26/contract-check-fork-conflation-investigation.md)) is already fixed on `fix/audit-contract-fork-conflation`:
+
+1. **Issue #13 (psycopg2 import error blocks audit)** — `import psycopg2` moved from module-top of `reporium_audit/checks/knowledge_graph.py` into the body of `check_knowledge_graph()`, guarded with `try/except ImportError`. Lazy import preserves the SKIP-when-`DATABASE_URL`-empty contract.
+2. **`isFork OR isPrivate` conflation in `contract.py:37`** — replaced with `isPrivate`-only filter; check name renamed `"contract: no private repos exposed"`; detail strings updated to drop `/fork`.
+
+A regression test fixture was committed alongside (`tests/test_contract.py`):
+- `test_forks_alone_do_not_trigger_privacy_failure` — three pure-fork repos return `PASS`.
+- `test_private_repo_triggers_failure` — one `isPrivate=true` row produces `FAIL` with `"1 private"` in the detail.
+- `test_clean_public_originals_pass` — mixed clean catalog with no private rows returns `PASS`.
+
+**This lane (2026-04-27) added missing-`psycopg2` test coverage** that the original commit did not include. The pre-existing `test_knowledge_graph_skips_when_db_url_missing` only covered the empty-`DATABASE_URL` SKIP path; the runner-survival contract for "missing `psycopg2` does not abort `asyncio.gather`" was not pinned. Two new tests in `tests/test_knowledge_graph_wiring.py` close that gap (see "Tests added by this lane" below).
+
+The lane is now a hygiene closeout: open the PR (now with the additional KG tests), merge to `main`, re-trigger the audit workflow once the merge lands so the missed 2026-04-26 row is filled.
+
+## What's on the branch
+
+```
+e0edcd1 fix(audit): drop fork conflation and lazy-import psycopg2
+```
+
+`git diff main HEAD` (verified 2026-04-27):
+
+```diff
+diff --git a/reporium_audit/checks/contract.py b/reporium_audit/checks/contract.py
+@@ -33,12 +33,15 @@ async def check_contract(api_url: str) -> list[dict]:
+             data = r.json()
+             repos = data.get("repos", [])
+
+-            # Check: no private repos
+-            private = [repo["name"] for repo in repos if repo.get("isFork") or repo.get("isPrivate")]
++            # Check: no private repos.
++            # Forks are intentionally part of the curated catalog (Reporium's
++            # product surface is forks of upstream open-source repos), so they
++            # are not a privacy violation. Only ``isPrivate=true`` is.
++            private = [repo["name"] for repo in repos if repo.get("isPrivate")]
+             results.append({
+-                "check": "contract: no private/fork repos exposed",
++                "check": "contract: no private repos exposed",
+                 "status": "PASS" if len(private) == 0 else "FAIL",
+-                "detail": f"{len(repos)} repos, {len(private)} private/fork" if private else f"{len(repos)} public owned repos",
++                "detail": f"{len(repos)} repos, {len(private)} private" if private else f"{len(repos)} public repos",
+             })
+
+diff --git a/reporium_audit/checks/knowledge_graph.py b/reporium_audit/checks/knowledge_graph.py
+@@ -21,8 +21,6 @@ from __future__ import annotations
+ from datetime import datetime, timedelta, timezone
+
+-import psycopg2
+-
+
+ STALE_RUN_THRESHOLD = timedelta(hours=25)
+
+@@ -46,6 +44,19 @@ async def check_knowledge_graph(db_url: str) -> list[dict]:
+         })
+         return results
+
++    # psycopg2 is imported lazily so the SKIP path above doesn't require the
++    # dep. The audit's declared deps are httpx + python-dotenv only; psycopg2
++    # is only needed when DATABASE_URL is set (issue #13).
++    try:
++        import psycopg2
++    except ImportError as e:
++        results.append({
++            "check": "knowledge graph edge counts",
++            "status": "FAIL",
++            "detail": f"psycopg2 not installed: {e}",
++        })
++        return results
++
+     try:
+         conn = psycopg2.connect(db_url)
+```
+
+Plus the new `tests/test_contract.py` (107 lines, three test cases, all parametrized via `respx.mock` against `httpx.AsyncClient`).
+
+## Tests added by this lane (2026-04-27)
+
+`tests/test_knowledge_graph_wiring.py` previously had two tests: one that pins the import wiring into `__main__`, one that covers the empty-`DATABASE_URL` SKIP path. Neither covered the missing-`psycopg2` runtime path. This lane adds two more:
+
+- `test_knowledge_graph_does_not_crash_when_psycopg2_missing` — uses `monkeypatch.setitem(sys.modules, "psycopg2", None)` to force the in-function `import psycopg2` to raise `ModuleNotFoundError`. Asserts the function returns a single result row (status FAIL, detail mentions `"psycopg2"`) and does **not** raise. This is the runner-survival contract — the `asyncio.gather` in `__main__.run_audit` cannot tolerate any check raising.
+- `test_knowledge_graph_skip_path_does_not_import_psycopg2` — same monkeypatch, but called with `db_url=""`. Asserts the SKIP path completes without ever needing `psycopg2`, pinning the issue-#13 contract that the audit's declared deps remain `httpx + python-dotenv` only.
+
+The first test's assertion `"psycopg2" in row["detail"]` is RED-discriminating against an unfixed module-top-import scenario:
+
+| Scenario | `row["detail"]` | `"psycopg2" in detail` |
+|---|---|---|
+| **Fixed (lazy import + missing psycopg2)** | `"psycopg2 not installed: …"` | True (test PASSes) |
+| **Unfixed (module-top import, psycopg2 already loaded in test env)** | `"DB error: could not translate host name 'unused-host' to address …"` | False (test FAILs) |
+
+So a future regression that slides the import back to module-top will be caught.
+
+Full local suite after additions: **33 passed, 0 failed** (was 31 before this lane).
+
+```
+$ python -m pytest tests/ -v
+============================= 33 passed in 2.86s ==============================
+```
+
+## Suggested PR body
+
+```
+fix(audit): drop fork conflation and lazy-import psycopg2
+
+Bundles two correlated fixes that together unblock the nightly audit:
+
+1. Lazy psycopg2 import (closes #13). The module-top import broke
+   `python -m reporium_audit` on every CI runner that hadn't pip-installed
+   psycopg2 — which is most of them, since the README declares only httpx
+   and python-dotenv as deps. The import is now inside check_knowledge_graph
+   and guarded with try/except ImportError, preserving the SKIP-when-
+   DATABASE_URL-empty contract.
+
+2. Drop isFork-or-isPrivate conflation in contract.py. Reporium's product
+   surface is forks of upstream open-source repos; flagging every fork as
+   a privacy violation would FAIL the audit on every clean nightly. The
+   check now matches only isPrivate=true. The check name and detail strings
+   were updated to drop "/fork" from the user-visible messages.
+
+Why bundled: once #1 lands the audit starts running cleanly, and that
+immediately surfaces the conflation as a false-positive privacy alarm.
+Shipping them separately would mean a window where the operator sees a
+false red. Bundling avoids the window.
+
+Tests added in tests/test_contract.py (respx-mocked httpx):
+- test_forks_alone_do_not_trigger_privacy_failure (regression for #2)
+- test_private_repo_triggers_failure (genuine privacy still caught)
+- test_clean_public_originals_pass (mixed catalog still passes)
+
+Tests added in tests/test_knowledge_graph_wiring.py (2026-04-27 follow-up):
+- test_knowledge_graph_does_not_crash_when_psycopg2_missing (runner-survival
+  contract — pins that asyncio.gather cannot abort on missing psycopg2)
+- test_knowledge_graph_skip_path_does_not_import_psycopg2 (declared-deps
+  contract — SKIP path remains psycopg2-free)
+
+Provenance:
+- .audit/2026-04-26/contract-check-fork-conflation-investigation.md
+- .audit/2026-04-27/audit-nightly-unblock.md (this lane's handoff)
+
+Closes #13.
+```
+
+## Operator steps after merge
+
+```sh
+# 1. Merge
+gh pr merge --squash --repo perditioinc/reporium-audit <PR>
+
+# 2. Trigger the audit so the missed 2026-04-26 nightly row gets filled
+gh workflow run audit.yml --repo perditioinc/reporium-audit
+
+# 3. Verify both gates pass on the next run
+gh run watch --repo perditioinc/reporium-audit
+```
+
+Expected output, reading the workflow log for the `check_contract` and `check_knowledge_graph` rows:
+
+- `contract: no private repos exposed` → **PASS** (200 forks, 0 private)
+- `contract: no null required fields` → **PASS** (0 nulls)
+- `contract: no null enriched fields` → **PASS** or **WARN** (depends on enrichment coverage; not blocking)
+- `knowledge graph build freshness` → **FAIL** today, will flip to **PASS** as soon as the Nightly Graph Build is unblocked (separate lane, R1 in the audit ranking)
+- `knowledge graph DEPENDS_ON > 0` → **PASS** (89 edges, per Apr 19 snapshot — this number lives in `v_edge_count_by_run`, not the audit code)
+
+If the contract gate FAILs after this merge, the failure shape is now meaningful — it means there really *is* an `isPrivate=true` row in `/library/full`, and the operator should investigate immediately. Before this merge, the gate was guaranteed to FAIL on every fork-bearing nightly and the signal was useless.
+
+## What this lane does NOT do
+
+- Does not push the branch (`fix/audit-contract-fork-conflation` is already on origin per the 2026-04-26 lane log).
+- Does not open the PR — operator action.
+- Does not change `knowledge graph build freshness`. That's blocked on Cloud SQL secret rotation in `reporium-ingestion` ops (separate lane, R1 in the audit dashboard).
+- Does not address the `enriched fields` `null` rate. The contract check returns `WARN` not `FAIL` on missing enriched fields; that's the right behavior. Populating those fields lives in the queued `source-attestation-enrichment-spec` lane.
+
+## `gh workflow run audit.yml` — was it triggered?
+
+**No.** This lane did not invoke `gh workflow run audit.yml --repo perditioinc/reporium-audit`. Two reasons:
+
+1. **The fix is on the unmerged branch `fix/audit-contract-fork-conflation`.** The scheduled `audit.yml` workflow runs against `main`. Triggering it pre-merge would re-execute the broken `main` code and reproduce the same crash, which gives no signal about whether the fix works.
+2. **A workflow run is shared-state.** It writes a row to the workflow history that an operator scanning recent runs could mistake for a clean post-merge result. Cleaner to merge first, then trigger (or wait for the 08:00 UTC scheduled run) so the green/red signal is unambiguous.
+
+The intended sequence remains the one in "Operator steps after merge" above.
+
+## Remaining risk
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| **Branch isn't merged** — the fix is local-only until a PR opens and merges. The next 08:00 UTC scheduled run on `main` will still crash. | High (today) | Open PR; tests are green so review should be quick. |
+| **PR conflicts with `main`** — the branch was last touched 2026-04-26 03:18 PDT plus this lane's test addition; main may have moved. | Low | Standard rebase. The two production files (`contract.py`, `knowledge_graph.py`) are not high-traffic. |
+| **First post-merge nightly genuinely surfaces an `isPrivate=true` row** — with the conflation removed, the check is now a true privacy alarm. Any FAIL after merge is no longer noise. | Low (live probe 2026-04-26 showed 0 of 200) | This is the desired contract. Document in PR description so operators don't dismiss the first FAIL as a regression. |
+| **CI environment loses `psycopg2`** — the new test pins the runtime degradation, not the CI install step. If CI's dev-deps install drops `psycopg2`, the audit completes but the KG check goes FAIL. | Low | The CI install step lives in `.github/workflows/audit.yml`; this lane did not change it. |
+| **Other module-top imports of optional deps** — this lane only fixed `psycopg2`. Any other check that does a module-top `import optional_dep` has the same bug shape. | Unknown — out of scope | A grep across `reporium_audit/checks/*.py` for module-top imports of non-declared deps is a 5-minute follow-up. |
+| **`/library/full` schema drift** — the contract check assumes `repo.get("isPrivate")` returns a falsy value for public repos. If the API ever stops emitting `isPrivate` entirely, the check trivially passes. | Low | A separate "schema completeness" check on `/library/full` could pin that the field exists per row; out of scope here. |
+
+## Provenance
+
+- 2026-04-26 contract investigation: `reporium-audit/.audit/2026-04-26/contract-check-fork-conflation-investigation.md`
+- Contract source on `fix/audit-contract-fork-conflation` HEAD `e0edcd1`: `reporium_audit/checks/contract.py` (lines 36–46), `reporium_audit/checks/knowledge_graph.py` (lines 47–58)
+- Test fixture: `tests/test_contract.py` HEAD `e0edcd1`
+- Diff against `main`: verified clean 2026-04-27 via `git diff main HEAD`
+
+---
+
+## Update — 2026-04-27 (Cowork 10h coordinator session — audit-nightly merge watch)
+
+**Anchor:** 2026-04-27 (Pacific morning, several hours after this handoff was filed).
+**Lane:** Cowork 10h coordinator session, Workstream D (audit-nightly merge / workflow verification watch).
+**Posture:** read-only. No edits to the fix branch, no PR opened, no workflow triggered. Working-tree edits to other `.audit/2026-04-24/*.md` files visible in `git status -sb` are unrelated to this lane and were not touched.
+
+### Branch state — verified locally (read-only)
+
+| Surface | Reading | Verdict |
+|---|---|---|
+| `main` HEAD (local + origin) | `bfb1366 docs: audit weekly operator pack (#11)` | unchanged since prior to this fix lane |
+| `fix/audit-contract-fork-conflation` HEAD (local + origin) | `e0edcd1 fix(audit): drop fork conflation and lazy-import psycopg2` | unchanged from this handoff's stated HEAD |
+| Distance | **1 commit ahead of main** | fix not yet merged |
+| Local-vs-origin parity on the fix branch | `## fix/audit-contract-fork-conflation...origin/fix/audit-contract-fork-conflation` (no ahead/behind) | tracked, pushed |
+| `tests/test_knowledge_graph_wiring.py` working-tree state | clean against HEAD; file contains all 4 tests including `test_knowledge_graph_does_not_crash_when_psycopg2_missing` (line 37) and `test_knowledge_graph_skip_path_does_not_import_psycopg2` (line 53) | the two new tests this handoff names as "added by this lane (2026-04-27)" are committed in `e0edcd1`, not uncommitted |
+
+**Net:** `e0edcd1` is the single, complete fix commit (lazy psycopg2 + contract de-conflation + the four contract tests + the two new wiring tests). It is on the branch, on origin, and **not on `main`**. The handoff's "Status: code complete on branch + missing-psycopg2 test coverage added — needs PR + merge" remains accurate.
+
+### Workflow state — NOT LIVE-VERIFIED
+
+Cowork's sandbox does not have `gh` CLI installed and `apt-get install gh` is blocked (no sudo / no-new-privileges). The handoff's "Operator steps after merge" §3 (`gh run watch`) cannot be exercised by Cowork. The exact `gh` checks the operator should run after merge are unchanged from §"Operator steps after merge"; this Update adds the **pre-merge** check the operator may want first:
+
+```bash
+# Pre-merge: is there already an open PR for this branch?
+gh pr list --repo perditioinc/reporium-audit \
+  --head fix/audit-contract-fork-conflation \
+  --state all \
+  --json number,state,isDraft,mergeable,baseRefName,statusCheckRollup,reviewDecision
+
+# If no PR exists, open one with the suggested body in §"Suggested PR body":
+gh pr create --repo perditioinc/reporium-audit \
+  --head fix/audit-contract-fork-conflation --base main \
+  --title 'fix(audit): drop fork conflation and lazy-import psycopg2' \
+  --body-file <(cat <<'PRBODY'
+[paste from §"Suggested PR body" of audit-nightly-unblock.md]
+PRBODY
+)
+
+# Pre-merge: latest run of audit.yml on origin/main (the broken one).
+# Should be a failure ("ImportError: psycopg2") prior to this fix.
+gh run list --repo perditioinc/reporium-audit --workflow audit.yml --limit 5 \
+  --json databaseId,headBranch,headSha,conclusion,createdAt,event
+```
+
+Audit.yml has not been triggered by Cowork (the handoff's §"`gh workflow run audit.yml` — was it triggered?" already explains why pre-merge triggers are not useful). Cowork is not authorized to merge.
+
+### Disposition
+
+- **Blocked: fix branch not merged to `main`.** No code action by Cowork. The next operator action is the §"Suggested PR body" + §"Operator steps after merge" sequence, unchanged from the original handoff.
+- The two new wiring tests are committed and pushed; PR description should call them out (the §"Suggested PR body" already does).
+- After merge, the operator runs `gh workflow run audit.yml --repo perditioinc/reporium-audit` once on `main` and verifies the run via `gh run watch`. Cowork records the post-merge run id below when/if the operator pastes it; this Update does not pre-fill.
+
+### Cowork did NOT
+
+- open the PR
+- merge the branch
+- push, rebase, or amend any commit
+- trigger `audit.yml` (pre-merge against `main` would re-execute the broken code; post-merge requires merge first — neither is in Cowork's scope)
+- modify any file in `reporium_audit/`, `tests/`, `.github/workflows/`, or `pyproject.toml`
+- read any secret or print any credential
+
+### Mirror
+
+A copy of this Update is staged at:
+`C:\DEV\PERDITIO_PLATFORM\.cowork-2026-04-27\parallel-lanes\audit-nightly-watch.md`
+(Lane prompt's intended `parallel-lanes\` path is unmounted in unsupervised Cowork — see `cowork-10h-session-log.md` §"path constraints".)

--- a/reporium_audit/checks/contract.py
+++ b/reporium_audit/checks/contract.py
@@ -33,12 +33,15 @@ async def check_contract(api_url: str) -> list[dict]:
             data = r.json()
             repos = data.get("repos", [])
 
-            # Check: no private repos
-            private = [repo["name"] for repo in repos if repo.get("isFork") or repo.get("isPrivate")]
+            # Check: no private repos.
+            # Forks are intentionally part of the curated catalog (Reporium's
+            # product surface is forks of upstream open-source repos), so they
+            # are not a privacy violation. Only ``isPrivate=true`` is.
+            private = [repo["name"] for repo in repos if repo.get("isPrivate")]
             results.append({
-                "check": "contract: no private/fork repos exposed",
+                "check": "contract: no private repos exposed",
                 "status": "PASS" if len(private) == 0 else "FAIL",
-                "detail": f"{len(repos)} repos, {len(private)} private/fork" if private else f"{len(repos)} public owned repos",
+                "detail": f"{len(repos)} repos, {len(private)} private" if private else f"{len(repos)} public repos",
             })
 
             # Check: no null required fields

--- a/reporium_audit/checks/knowledge_graph.py
+++ b/reporium_audit/checks/knowledge_graph.py
@@ -21,8 +21,6 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-import psycopg2
-
 
 STALE_RUN_THRESHOLD = timedelta(hours=25)
 
@@ -43,6 +41,19 @@ async def check_knowledge_graph(db_url: str) -> list[dict]:
             "check": "knowledge graph edge counts",
             "status": "SKIP",
             "detail": "DATABASE_URL not set -- audit runner has no DB credentials",
+        })
+        return results
+
+    # psycopg2 is imported lazily so the SKIP path above doesn't require the
+    # dep. The audit's declared deps are httpx + python-dotenv only; psycopg2
+    # is only needed when DATABASE_URL is set (issue #13).
+    try:
+        import psycopg2
+    except ImportError as e:
+        results.append({
+            "check": "knowledge graph edge counts",
+            "status": "FAIL",
+            "detail": f"psycopg2 not installed: {e}",
         })
         return results
 

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,106 @@
+"""Tests for /library/full data-contract checks.
+
+Pins the 2026-04-26 fix that stopped conflating ``isFork`` with
+``isPrivate``. Reporium's curated catalog intentionally contains forks
+of upstream open-source repos -- forks are the product, not a privacy
+violation. Only ``isPrivate=true`` rows constitute a contract failure.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from reporium_audit.checks.contract import check_contract
+
+
+API_URL = "https://api.example.test"
+LIBRARY_FULL_URL = f"{API_URL}/library/full"
+
+
+def _repo(name: str, *, is_fork: bool = False, is_private: bool = False) -> dict:
+    return {
+        "name": name,
+        "fullName": f"perditioinc/{name}",
+        "description": "x",
+        "url": f"https://github.com/perditioinc/{name}",
+        "stars": 1,
+        "forks": 0,
+        "isFork": is_fork,
+        "isPrivate": is_private,
+        # enriched fields populated to keep null-checks PASS
+        "readmeSummary": "x",
+        "primaryCategory": "ai",
+        "allCategories": [],
+        "enrichedTags": [],
+        "builders": [],
+        "pmSkills": [],
+        "industries": [],
+        "aiDevSkills": [],
+        "programmingLanguages": [],
+        "commitStats": {},
+        "languageBreakdown": {},
+        "languagePercentages": {},
+    }
+
+
+def _privacy_row(results: list[dict]) -> dict:
+    matches = [r for r in results if "private" in r["check"]]
+    assert len(matches) == 1, f"expected exactly one privacy row, got {results}"
+    return matches[0]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_forks_alone_do_not_trigger_privacy_failure():
+    """Regression: forks are the product surface, not a privacy violation."""
+    repos = [_repo(f"fork-{i}", is_fork=True) for i in range(3)]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+
+    results = await check_contract(API_URL)
+
+    row = _privacy_row(results)
+    assert row["status"] == "PASS"
+    assert "private" in row["check"]
+    assert "fork" not in row["check"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_private_repo_triggers_failure():
+    """Privacy check still catches genuine private exposure."""
+    repos = [
+        _repo("public-fork", is_fork=True),
+        _repo("leaked", is_private=True),
+    ]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+
+    results = await check_contract(API_URL)
+
+    row = _privacy_row(results)
+    assert row["status"] == "FAIL"
+    assert "1 private" in row["detail"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_clean_public_originals_pass():
+    """Mixed clean catalog with no private rows should PASS."""
+    repos = [
+        _repo("original-1"),
+        _repo("fork-1", is_fork=True),
+    ]
+    respx.get(LIBRARY_FULL_URL).mock(
+        return_value=httpx.Response(200, json={"repos": repos})
+    )
+
+    results = await check_contract(API_URL)
+
+    row = _privacy_row(results)
+    assert row["status"] == "PASS"
+    assert "2 public repos" in row["detail"]

--- a/tests/test_knowledge_graph_wiring.py
+++ b/tests/test_knowledge_graph_wiring.py
@@ -3,9 +3,16 @@
 Before 2026-04-24, ``knowledge_graph.py`` existed but was never imported
 by ``__main__``. This test pins the import so the regression can't
 recur silently.
+
+The remaining tests pin the issue-#13 degradation policy: the runner
+gathers checks with ``asyncio.gather``, so a raw ``ImportError`` or
+crash inside any check aborts the entire audit. Both no-``DATABASE_URL``
+and missing-``psycopg2`` paths must return a result row, not raise.
 """
 
 from __future__ import annotations
+
+import sys
 
 import pytest
 
@@ -21,6 +28,38 @@ def test_knowledge_graph_is_imported_by_runner():
 @pytest.mark.asyncio
 async def test_knowledge_graph_skips_when_db_url_missing():
     results = await check_knowledge_graph("")
+    assert len(results) == 1
+    assert results[0]["status"] == "SKIP"
+    assert "DATABASE_URL" in results[0]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_graph_does_not_crash_when_psycopg2_missing(monkeypatch):
+    """Missing ``psycopg2`` must surface as a result row, not a raised
+    ``ImportError``. Otherwise the runner's ``asyncio.gather`` would
+    propagate the error and abort the full audit (issue #13)."""
+    monkeypatch.setitem(sys.modules, "psycopg2", None)
+
+    results = await check_knowledge_graph("postgresql://unused-host/db")
+
+    assert isinstance(results, list)
+    assert len(results) == 1
+    row = results[0]
+    assert row["status"] in {"FAIL", "SKIP"}
+    assert "psycopg2" in row["detail"]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_graph_skip_path_does_not_import_psycopg2(monkeypatch):
+    """The empty-``DATABASE_URL`` SKIP path must not require ``psycopg2``.
+
+    The audit's declared deps are httpx + python-dotenv only; importing
+    ``psycopg2`` at module top would crash CI envs that have no DB
+    access, regardless of whether ``DATABASE_URL`` was set."""
+    monkeypatch.setitem(sys.modules, "psycopg2", None)
+
+    results = await check_knowledge_graph("")
+
     assert len(results) == 1
     assert results[0]["status"] == "SKIP"
     assert "DATABASE_URL" in results[0]["detail"]


### PR DESCRIPTION
Rescued local-only work from the 2026-06-14 local-work audit: tests/test_knowledge_graph_wiring.py (+39 lines) asserting a missing psycopg2 returns a result row instead of raising. Was an uncommitted working-tree edit.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>