### PR TITLE
fix(build): scope setuptools package discovery to reporium_audit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "respx>=0.21", "ruff>=0.4"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 
+[tool.setuptools.packages.find]
+include = ["reporium_audit*"]
+exclude = ["security*", "tests*"]
+
 [build-system]
 requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Problem

`pip install -e ".[dev]"` fails in CI (PR workflow, `Install dev dependencies` step) with:

```
error: Multiple top-level packages discovered in a flat-layout: ['security', 'reporium_audit'].
```

The repo uses a flat layout with multiple top-level directories (`reporium_audit/`, `security/`, `tests/`). With no explicit package configuration, setuptools auto-discovery refuses to proceed when it finds more than one top-level package.

## Fix

Add an explicit `[tool.setuptools.packages.find]` section that scopes discovery to the actual library package:

```toml
[tool.setuptools.packages.find]
include = ["reporium_audit*"]
exclude = ["security*", "tests*"]
```

This matches the real directory name (`reporium_audit`) and excludes the `security/` helper tree and `tests/`.

## Verification

Reproduced the exact `Multiple top-level packages discovered` error against the current config, then confirmed the fix in an isolated venv:

- `pip install -e .` exits 0
- package discovery resolves to `['reporium_audit']`
- `import reporium_audit` succeeds

Minimal change, build config only. No source or test changes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
